### PR TITLE
feat(): Add reading dictionary

### DIFF
--- a/src/main/kotlin/com/inout/apiserver/application/word/ReadWordsApplication.kt
+++ b/src/main/kotlin/com/inout/apiserver/application/word/ReadWordsApplication.kt
@@ -1,0 +1,28 @@
+package com.inout.apiserver.application.word
+
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.domain.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+
+@Component
+class ReadWordsApplication(
+    private val wordRepository: WordRepository,
+) {
+    fun run(
+        fromLanguage: LanguageType,
+        toLanguage: LanguageType,
+        prefix: String,
+        lexicalCategoryType: LexicalCategoryType?,
+        pageable: Pageable
+    ): Pair<Long, List<Word>> {
+        val words =
+            wordRepository.findWordsWithDefinitions(fromLanguage, toLanguage, prefix, lexicalCategoryType, pageable)
+
+        return Pair(words.totalElements, words.content)
+    }
+}

--- a/src/main/kotlin/com/inout/apiserver/config/ControllerAdvice.kt
+++ b/src/main/kotlin/com/inout/apiserver/config/ControllerAdvice.kt
@@ -16,6 +16,8 @@ data class ErrorResponse(
 
 @ControllerAdvice
 class ControllerAdvice {
+    // TODO:phil, e: HttpException won't bind properly, create specific exception interfaces
+    //  if multiple exceptions are needed for a single handler
     @ExceptionHandler(ConflictException::class)
     fun handleConflictException(e: HttpException): ResponseEntity<ErrorResponse> {
         return ResponseEntity

--- a/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordJpaRepository.kt
+++ b/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordJpaRepository.kt
@@ -1,9 +1,14 @@
 package com.inout.apiserver.infrastructure.db.word
 
 import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Query
 
-interface WordJpaRepository : JpaRepository<WordEntity, Long> {
+interface WordJpaRepository : JpaRepository<WordEntity, Long>, JpaSpecificationExecutor<WordEntity> {
     fun findByNameAndFromLanguageAndToLanguage(
         name: String,
         fromLanguage: LanguageType,

--- a/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordRepository.kt
+++ b/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordRepository.kt
@@ -1,7 +1,11 @@
 package com.inout.apiserver.infrastructure.db.word
 
 import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.domain.word.Word
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -18,5 +22,20 @@ class WordRepository(
 
     fun findById(id: Long): Word? {
         return wordJpaRepository.findById(id).orElse(null)?.toDomain()
+    }
+
+    fun findWordsWithDefinitions(
+        fromLanguage: LanguageType,
+        toLanguage: LanguageType,
+        prefix: String,
+        lexicalCategoryType: LexicalCategoryType?,
+        pageable: Pageable
+    ): Page<Word> {
+        val spec = Specification.where(WordSpecification.fromLanguage(fromLanguage))
+            .and(WordSpecification.toLanguage(toLanguage))
+            .and(WordSpecification.prefix(prefix))
+            .and(WordSpecification.lexicalCategoryType(lexicalCategoryType))
+
+        return wordJpaRepository.findAll(spec, pageable).map { it.toDomain() }
     }
 }

--- a/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordSpecification.kt
+++ b/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordSpecification.kt
@@ -1,0 +1,38 @@
+package com.inout.apiserver.infrastructure.db.word
+
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import jakarta.persistence.criteria.JoinType
+import org.springframework.data.jpa.domain.Specification
+
+class WordSpecification {
+    companion object {
+        fun fromLanguage(fromLanguage: LanguageType): Specification<WordEntity> {
+            return Specification { root, _, criteriaBuilder ->
+                criteriaBuilder.equal(root.get<LanguageType>("fromLanguage"), fromLanguage)
+            }
+        }
+
+        fun toLanguage(toLanguage: LanguageType): Specification<WordEntity> {
+            return Specification { root, _, criteriaBuilder ->
+                criteriaBuilder.equal(root.get<LanguageType>("toLanguage"), toLanguage)
+            }
+        }
+
+        fun prefix(prefix: String): Specification<WordEntity> {
+            return Specification { root, _, criteriaBuilder ->
+                criteriaBuilder.like(root.get("name"), "$prefix%")
+            }
+        }
+
+        fun lexicalCategoryType(lexicalCategoryType: LexicalCategoryType?): Specification<WordEntity> {
+            return Specification { root, _, criteriaBuilder ->
+                if (lexicalCategoryType == null) {
+                    return@Specification criteriaBuilder.conjunction()
+                }
+                val definitions = root.join<WordEntity, WordDefinitionEntity>("definitions", JoinType.INNER)
+                criteriaBuilder.equal(definitions.get<LexicalCategoryType>("lexicalCategory"), lexicalCategoryType)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/WordController.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/WordController.kt
@@ -2,11 +2,15 @@ package com.inout.apiserver.interfaces.web.v1
 
 import com.inout.apiserver.application.word.CreateWordApplication
 import com.inout.apiserver.application.word.ReadWordApplication
+import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.interfaces.web.v1.apiSpec.WordApiSpec
 import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
 import com.inout.apiserver.interfaces.web.v1.request.ReadWordRequest
+import com.inout.apiserver.interfaces.web.v1.response.ResponsePaginationWrapper
+import com.inout.apiserver.interfaces.web.v1.response.WordDefinitionResponse
 import com.inout.apiserver.interfaces.web.v1.response.WordResponse
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,5 +29,13 @@ class WordController(
 
     override fun readWord(@RequestBody @Valid request: ReadWordRequest): ResponseEntity<WordResponse> {
         return ResponseEntity(readWordApplication.run(request), OK)
+    }
+
+    override fun readWordDefinitionsWithMatchingPrefix(
+        pageable: Pageable,
+        prefix: String,
+        lexicalCategoryType: LexicalCategoryType?
+    ): ResponseEntity<ResponsePaginationWrapper<WordDefinitionResponse>> {
+        return ResponseEntity(ResponsePaginationWrapper(emptyList(), 0, 0, 0), OK)
     }
 }

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/WordController.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/WordController.kt
@@ -1,15 +1,19 @@
 package com.inout.apiserver.interfaces.web.v1
 
 import com.inout.apiserver.application.word.CreateWordApplication
+import com.inout.apiserver.application.word.ReadWordsApplication
 import com.inout.apiserver.application.word.ReadWordApplication
+import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.domain.word.Word
 import com.inout.apiserver.interfaces.web.v1.apiSpec.WordApiSpec
 import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
 import com.inout.apiserver.interfaces.web.v1.request.ReadWordRequest
 import com.inout.apiserver.interfaces.web.v1.response.ResponsePaginationWrapper
-import com.inout.apiserver.interfaces.web.v1.response.WordDefinitionResponse
 import com.inout.apiserver.interfaces.web.v1.response.WordResponse
+import com.inout.apiserver.interfaces.web.v1.response.WordWithDefinitionsResponse
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
@@ -22,6 +26,7 @@ import org.springframework.http.HttpStatus.*
 class WordController(
     private val createWordApplication: CreateWordApplication,
     private val readWordApplication: ReadWordApplication,
+    private val readWordsApplication: ReadWordsApplication,
 ) : WordApiSpec {
     override fun createWord(@RequestBody @Valid request: CreateWordRequest): ResponseEntity<WordResponse> {
         return ResponseEntity(createWordApplication.run(request), CREATED)
@@ -31,11 +36,22 @@ class WordController(
         return ResponseEntity(readWordApplication.run(request), OK)
     }
 
-    override fun readWordDefinitionsWithMatchingPrefix(
+    override fun readWordsWithMatchingPrefix(
         pageable: Pageable,
+        fromLanguage: LanguageType,
+        toLanguage: LanguageType,
         prefix: String,
-        lexicalCategoryType: LexicalCategoryType?
-    ): ResponseEntity<ResponsePaginationWrapper<WordDefinitionResponse>> {
-        return ResponseEntity(ResponsePaginationWrapper(emptyList(), 0, 0, 0), OK)
+        lexicalCategory: LexicalCategoryType?,
+    ): ResponseEntity<ResponsePaginationWrapper<WordWithDefinitionsResponse>> {
+        val (count, words) =
+            readWordsApplication.run(fromLanguage, toLanguage, prefix, lexicalCategory, pageable)
+
+        return ResponseEntity(
+            ResponsePaginationWrapper(
+                data = words.map { WordWithDefinitionsResponse.of(it, lexicalCategory) },
+                hasMore = pageable.next().offset < count,
+                count = count
+            ), OK
+        )
     }
 }

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/apiSpec/WordApiSpec.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/apiSpec/WordApiSpec.kt
@@ -1,24 +1,31 @@
 package com.inout.apiserver.interfaces.web.v1.apiSpec
 
+import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.error.HttpException
 import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
 import com.inout.apiserver.interfaces.web.v1.request.ReadWordRequest
+import com.inout.apiserver.interfaces.web.v1.response.ResponsePaginationWrapper
+import com.inout.apiserver.interfaces.web.v1.response.WordDefinitionResponse
 import com.inout.apiserver.interfaces.web.v1.response.WordResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.SchemaProperty
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.data.domain.Pageable
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 
 interface WordApiSpec {
     @PostMapping
     @Operation(
-        summary = "글로벌 사전 단어 등록",
-        description = "글로벌 사전 단어 등록을 요청합니다.",
+        summary = "사전 단어 등록",
+        description = "사전 단어 등록을 요청합니다.",
         requestBody = SwaggerRequestBody(
             description = "단어 생성 요청값",
             required = true,
@@ -32,7 +39,7 @@ interface WordApiSpec {
         responses = [
             ApiResponse(
                 responseCode = "201",
-                description = "글로벌 사전에 단어 등록 성공",
+                description = "사전에 단어 등록 성공",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -42,7 +49,7 @@ interface WordApiSpec {
             ),
             ApiResponse(
                 responseCode = "409",
-                description = "글로벌 사전에 단어 등록 실패 (code: WORD_1) - 이미 존재하는 단어",
+                description = "사전에 단어 등록 실패 (code: WORD_1) - 이미 존재하는 단어",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -57,8 +64,9 @@ interface WordApiSpec {
 
     @GetMapping
     @Operation(
-        summary = "글로벌 사전 단어 조회",
-        description = "글로벌 사전 단어 조회를 요청합니다.",
+        deprecated = true,
+        summary = "사전 단어 조회 (deprecated, /words/definitions로 대체)",
+        description = "사전 단어 조회를 요청합니다.",
         requestBody = SwaggerRequestBody(
             description = "단어 조회 요청값",
             required = true,
@@ -72,7 +80,7 @@ interface WordApiSpec {
         responses = [
             ApiResponse(
                 responseCode = "200",
-                description = "글로벌 사전에 단어 조회 성공",
+                description = "사전에 단어 조회 성공",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -82,7 +90,7 @@ interface WordApiSpec {
             ),
             ApiResponse(
                 responseCode = "404",
-                description = "글로벌 사전에 단어 조회 실패 (code: WORD_2) - 단어가 존재하지 않음",
+                description = "사전에 단어 조회 실패 (code: WORD_2) - 단어가 존재하지 않음",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -93,4 +101,68 @@ interface WordApiSpec {
         ]
     )
     fun readWord(@RequestBody request: ReadWordRequest): ResponseEntity<WordResponse>
+
+
+    @GetMapping("/definitions")
+    @Operation(
+        summary = "사전 단어 조회, prefix와 lexicalCategoryType으로 필터링 가능",
+        description = "사전 단어 정의 조회를 요청합니다.",
+        parameters = [
+            Parameter(
+                name = "pagable",
+                description = "페이지네이션 정보",
+                required = true,
+                schema = Schema(implementation = Pageable::class)
+            ),
+            Parameter(
+                name = "prefix",
+                description = "단어 prefix",
+                required = true,
+                schema = Schema(implementation = String::class)
+            ),
+            Parameter(
+                name = "lexicalCategoryType",
+                description = "단어 품사",
+                required = false,
+                schema = Schema(implementation = LexicalCategoryType::class)
+            )
+        ],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "사전에 단어 정의 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schemaProperties = [
+                            // TODO: this is too verbose, consider using a custom schema
+                            SchemaProperty(
+                                name = "data",
+                                schema = Schema(implementation = WordDefinitionResponse::class)
+                            ),
+                            SchemaProperty(
+                                name = "total",
+                                schema = Schema(implementation = Integer::class)
+                            ),
+                            SchemaProperty(
+                                name = "page",
+                                schema = Schema(implementation = Integer::class)
+                            ),
+                            SchemaProperty(
+                                name = "size",
+                                schema = Schema(implementation = Integer::class)
+                            ),
+                        ]
+                    )
+                ]
+            ),
+        ]
+    )
+    fun readWordDefinitionsWithMatchingPrefix(
+        pageable: Pageable,
+        @RequestParam(required = true)
+        prefix: String,
+        @RequestParam(required = false)
+        lexicalCategoryType: LexicalCategoryType?
+    ): ResponseEntity<ResponsePaginationWrapper<WordDefinitionResponse>>
 }

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/request/CreateWordRequest.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/request/CreateWordRequest.kt
@@ -6,11 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
 
 data class CreateWordRequest(
-    @field:NotEmpty
+    @NotEmpty
     @Schema(description = "단어 이름", example = "apple", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
 
-    @field:NotEmpty
+    @NotEmpty
     @Schema(
         description = "영한사전 기준 영어에 해당되는 값. ex) apple의 뜻을 한글로 알고싶을 경우 ENGLISH로 제공",
         example = "ENGLISH",
@@ -18,7 +18,7 @@ data class CreateWordRequest(
     )
     val fromLanguage: LanguageType,
 
-    @field:NotEmpty
+    @NotEmpty
     @Schema(
         description = "영한사전 기준 한국어에 해당되는 값. ex) apple의 뜻을 한글로 알고싶을 경우 KOREAN으로 제공",
         example = "KOREAN",

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ResponsePaginationWrapper.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ResponsePaginationWrapper.kt
@@ -2,7 +2,6 @@ package com.inout.apiserver.interfaces.web.v1.response
 
 data class ResponsePaginationWrapper<T>(
     val data: List<T>,
-    val total: Int,
-    val page: Int,
-    val size: Int
+    val hasMore: Boolean,
+    val count: Long,
 )

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ResponsePaginationWrapper.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ResponsePaginationWrapper.kt
@@ -1,0 +1,8 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+data class ResponsePaginationWrapper<T>(
+    val data: List<T>,
+    val total: Int,
+    val page: Int,
+    val size: Int
+)

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordDefinitionResponse.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordDefinitionResponse.kt
@@ -1,10 +1,22 @@
 package com.inout.apiserver.interfaces.web.v1.response
 
 import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.domain.word.WordDefinition
 
 data class WordDefinitionResponse(
     val id: Long,
     val lexicalCategory: LexicalCategoryType,
     val meaning: String,
     val preContext: String,
-)
+) {
+    companion object {
+        fun of(wordDefinition: WordDefinition): WordDefinitionResponse {
+            return WordDefinitionResponse(
+                id = wordDefinition.id,
+                lexicalCategory = wordDefinition.lexicalCategory,
+                meaning = wordDefinition.meaning,
+                preContext = wordDefinition.preContext,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordDefinitionResponse.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordDefinitionResponse.kt
@@ -1,0 +1,10 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+import com.inout.apiserver.base.enums.LexicalCategoryType
+
+data class WordDefinitionResponse(
+    val id: Long,
+    val lexicalCategory: LexicalCategoryType,
+    val meaning: String,
+    val preContext: String,
+)

--- a/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordWithDefinitionsResponse.kt
+++ b/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordWithDefinitionsResponse.kt
@@ -1,0 +1,39 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.domain.word.Word
+
+data class WordWithDefinitionsResponse(
+    val id: Long,
+    val name: String,
+    val fromLanguage: LanguageType,
+    val toLanguage: LanguageType,
+    val definitions: List<WordDefinitionResponse>
+) {
+    companion object {
+        fun of(word: Word): WordWithDefinitionsResponse {
+            return WordWithDefinitionsResponse(
+                id = word.id,
+                name = word.name,
+                fromLanguage = word.fromLanguage,
+                toLanguage = word.toLanguage,
+                definitions = word.definitions.map { WordDefinitionResponse.of(it) }
+            )
+        }
+
+        fun of(word: Word, lexicalCategoryType: LexicalCategoryType?): WordWithDefinitionsResponse {
+            return WordWithDefinitionsResponse(
+                id = word.id,
+                name = word.name,
+                fromLanguage = word.fromLanguage,
+                toLanguage = word.toLanguage,
+                definitions = word.definitions.filter {
+                    lexicalCategoryType == null || it.lexicalCategory == lexicalCategoryType
+                }.map {
+                    WordDefinitionResponse.of(it)
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
- deprecate old word reading api
  - currently seems to have no usage
- add JpaSpecificationExecutor to enable
  - like queries working as expected
  - provided lexical category of nullable handled as expected
  - add WordSpecification taking advantage of JpaSpecificationExecutor
- add reading word definitions application flow
- add findWordsWithDefinitions querying method
- add TODO to controller advice
  - parameter marked with HttpException won't bind correctly as there are many methods having the same parameter type

https://www.notion.so/SER-1bfe7aec2c504fbea83a92740b294a9d?pvs=4