### PR TITLE
feat(): 일별 학습셋 반환 

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-Duser.timezone=UTC","-jar","/app.jar"]

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,7 @@ tasks.register<Wrapper>("wrapper") {
 
 tasks.test {
     useJUnitPlatform()
+    systemProperties["user.timezone"] = "UTC"
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("org.springframework.boot") version "3.2.4"
     id("io.spring.dependency-management") version "1.1.4"
@@ -39,7 +37,6 @@ dependencies {
     implementation("io.ktor:ktor-client-okhttp:2.3.11")
     runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.1")
 
-
     // serialization
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -54,6 +51,7 @@ dependencies {
 
     // db
     runtimeOnly("org.postgresql:postgresql")
+    implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.8.2")
 
     // logins
     // google api client

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,5 +61,5 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("io.mockk:mockk:1.13.10")
-    testImplementation("com.h2database:h2")
+    testImplementation("org.postgresql:postgresql")
 }

--- a/app/src/main/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplication.kt
@@ -1,0 +1,77 @@
+package com.inout.apiserver.application.study
+
+import com.inout.apiserver.domain.study.DailyStudySet
+import com.inout.apiserver.domain.study.DailyStudySetCreateObject
+import com.inout.apiserver.domain.study.StudyService
+import com.inout.apiserver.domain.study.StudyWord
+import com.inout.apiserver.domain.word.Word
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.error.NotFoundException
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+@Component
+class ReadOrCreateDailyStudySetApplication(
+    private val studyService: StudyService,
+    private val wordService: WordService,
+) {
+    companion object {
+        const val DEFAULT_STUDY_SET_SIZE = 20 // TODO: later fix with user's settings
+    }
+
+    data class Result(
+        val dailyStudySet: DailyStudySet,
+        val studyWords: List<StudyWord>,
+    )
+
+    fun run(
+        userId: Long,
+        date: LocalDate,
+    ): Result {
+        val now = LocalDate.now()
+        if (date.isAfter(now)) {
+            throw BadRequestException(message = "Cannot request future daily study set", code = "STUDY_3")
+        }
+
+        var dailyStudySet = studyService.getDailyStudySet(userId, date)
+        if (date != LocalDate.now()) {
+            throw NotFoundException(message = "DailyStudySet not found", code = "STUDY_4")
+        }
+
+        if (dailyStudySet == null) {
+            dailyStudySet = studyService.createDailyStudySet(DailyStudySetCreateObject(userId, date))
+        }
+
+        val endOfDay = now.atStartOfDay().plusDays(1).toInstant(ZoneOffset.UTC)
+        val due = endOfDay.atZone(ZoneId.systemDefault()).toInstant()
+        val studies =
+            studyService.getStudiesByIds(dailyStudySet.studyIds) +
+                studyService.getStudiesPastDue(
+                    userId,
+                    due,
+                    DEFAULT_STUDY_SET_SIZE - dailyStudySet.studyIds.size,
+                )
+        val wordDefinitionIds = studies.map { it.wordDefinitionId }
+        val words = wordService.getWordsByWordDefinitionIds(wordDefinitionIds)
+        val wordByDefinitionIdMap = mutableMapOf<Long, Word>()
+        words.forEach { word ->
+            word.definitions.forEach { definition -> wordByDefinitionIdMap[definition.id] = word }
+        }
+
+        return Result(
+            dailyStudySet = dailyStudySet.copy(studyIds = dailyStudySet.studyIds + studies.map { it.id }),
+            studyWords =
+                studies.map { study ->
+                    StudyWord(
+                        study = study,
+                        word =
+                            wordByDefinitionIdMap[study.wordDefinitionId]
+                                ?: throw NotFoundException(message = "Data Integrity Error", code = "STUDY_2"),
+                    )
+                },
+        )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplication.kt
@@ -37,7 +37,8 @@ class ReadOrCreateDailyStudySetApplication(
         }
 
         var dailyStudySet = studyService.getDailyStudySet(userId, date)
-        if (date != LocalDate.now()) {
+        val isNotToday = date != now
+        if (isNotToday && dailyStudySet == null) {
             throw NotFoundException(message = "DailyStudySet not found", code = "STUDY_4")
         }
 
@@ -48,12 +49,19 @@ class ReadOrCreateDailyStudySetApplication(
         val endOfDay = now.atStartOfDay().plusDays(1).toInstant(ZoneOffset.UTC)
         val due = endOfDay.atZone(ZoneId.systemDefault()).toInstant()
         val studies =
-            studyService.getStudiesByIds(dailyStudySet.studyIds) +
-                studyService.getStudiesPastDue(
-                    userId,
-                    due,
-                    DEFAULT_STUDY_SET_SIZE - dailyStudySet.studyIds.size,
-                )
+            studyService.getStudiesByIds(dailyStudySet.studyIds).let {
+                it +
+                    if (isNotToday) {
+                        emptyList()
+                    } else {
+                        studyService.getStudiesPastDue(
+                            userId,
+                            due,
+                            DEFAULT_STUDY_SET_SIZE - it.size,
+                        )
+                    }
+            }
+
         val wordDefinitionIds = studies.map { it.wordDefinitionId }
         val words = wordService.getWordsByWordDefinitionIds(wordDefinitionIds)
         val wordByDefinitionIdMap = mutableMapOf<Long, Word>()
@@ -62,7 +70,7 @@ class ReadOrCreateDailyStudySetApplication(
         }
 
         return Result(
-            dailyStudySet = dailyStudySet.copy(studyIds = dailyStudySet.studyIds + studies.map { it.id }),
+            dailyStudySet = dailyStudySet.copy(studyIds = studies.map { it.id }),
             studyWords =
                 studies.map { study ->
                     StudyWord(

--- a/app/src/main/kotlin/com/inout/apiserver/config/ControllerAdvice.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/config/ControllerAdvice.kt
@@ -16,6 +16,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 data class ErrorResponse(
     override val code: String,
@@ -86,6 +87,13 @@ class ControllerAdvice {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(code = "BAD_REQUEST_2", message = "Bad Request", extraData = errorMap))
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(code = "BAD_REQUEST_3", message = "Bad Request", extraData = mapOf("field" to e.name)))
     }
 
     @ExceptionHandler(ForbiddenException::class)

--- a/app/src/main/kotlin/com/inout/apiserver/domain/study/DailyStudySet.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/study/DailyStudySet.kt
@@ -1,0 +1,10 @@
+package com.inout.apiserver.domain.study
+
+import java.time.LocalDate
+
+data class DailyStudySet(
+    val id: Long,
+    val userId: Long,
+    val studyIds: List<Long>,
+    val date: LocalDate,
+)

--- a/app/src/main/kotlin/com/inout/apiserver/domain/study/DailyStudySetCreateObject.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/study/DailyStudySetCreateObject.kt
@@ -1,0 +1,8 @@
+package com.inout.apiserver.domain.study
+
+import java.time.LocalDate
+
+data class DailyStudySetCreateObject(
+    val userId: Long,
+    val date: LocalDate,
+)

--- a/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
@@ -77,6 +77,13 @@ class StudyService(
     }
 
     fun createDailyStudySet(dailyStudySetCreateObject: DailyStudySetCreateObject): DailyStudySet {
+        getDailyStudySet(
+            userId = dailyStudySetCreateObject.userId,
+            date = dailyStudySetCreateObject.date,
+        )?.let {
+            throw ConflictException(message = "Daily study set already exists", code = "STUDY_5")
+        }
+
         return dailyStudySetRepository.save(DailyStudySetEntity.fromCreateObject(dailyStudySetCreateObject))
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
@@ -1,16 +1,21 @@
 package com.inout.apiserver.domain.study
 
 import com.inout.apiserver.error.ConflictException
+import com.inout.apiserver.infrastructure.db.study.DailyStudySetEntity
+import com.inout.apiserver.infrastructure.db.study.DailyStudySetRepository
 import com.inout.apiserver.infrastructure.db.study.StudyEntity
 import com.inout.apiserver.infrastructure.db.study.StudyRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.LocalDate
 
 @Service
 class StudyService(
     private val studyRepository: StudyRepository,
+    private val dailyStudySetRepository: DailyStudySetRepository,
 ) {
     fun getAllByUserId(
         userId: Long,
@@ -37,6 +42,22 @@ class StudyService(
         return studyRepository.findById(id)
     }
 
+    fun getStudiesPastDue(
+        userId: Long,
+        due: Instant,
+        count: Int,
+    ): List<Study> {
+        if (count <= 0) {
+            return emptyList()
+        }
+
+        return studyRepository.findAllPastDueStudiesBy(userId, due, PageRequest.of(0, count)).content
+    }
+
+    fun getStudiesByIds(ids: List<Long>): List<Study> {
+        return studyRepository.findAllByIds(ids)
+    }
+
     fun createStudy(studyCreateObject: StudyCreateObject): Study {
         getByUserIdAndWordDefinitionId(
             userId = studyCreateObject.userId,
@@ -46,5 +67,16 @@ class StudyService(
         }
 
         return studyRepository.save(StudyEntity.fromCreateObject(studyCreateObject))
+    }
+
+    fun getDailyStudySet(
+        userId: Long,
+        date: LocalDate,
+    ): DailyStudySet? {
+        return dailyStudySetRepository.findByUserIdAndDate(userId, date)
+    }
+
+    fun createDailyStudySet(dailyStudySetCreateObject: DailyStudySetCreateObject): DailyStudySet {
+        return dailyStudySetRepository.save(DailyStudySetEntity.fromCreateObject(dailyStudySetCreateObject))
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetEntity.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetEntity.kt
@@ -8,17 +8,23 @@ import io.hypersistence.utils.hibernate.type.array.ListArrayType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.Type
 import java.time.LocalDate
 
 @Entity
-@Table(name = "daily_study_sets")
+@Table(
+    name = "daily_study_sets",
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["user_id", "date"]),
+    ],
+)
 data class DailyStudySetEntity(
     val userId: Long,
+    val date: LocalDate,
     @Column(columnDefinition = "bigint[]", nullable = false, updatable = true, name = "study_ids")
     @Type(ListArrayType::class)
     val studyIds: List<Long>,
-    val date: LocalDate,
 ) : BaseEntity() {
     fun toDomain(): DailyStudySet {
         return DailyStudySet(

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetEntity.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetEntity.kt
@@ -1,0 +1,41 @@
+package com.inout.apiserver.infrastructure.db.study
+
+import com.inout.apiserver.domain.study.DailyStudySet
+import com.inout.apiserver.domain.study.DailyStudySetCreateObject
+import com.inout.apiserver.error.InOutRequireNotNullException
+import com.inout.apiserver.infrastructure.db.BaseEntity
+import io.hypersistence.utils.hibernate.type.array.ListArrayType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.Type
+import java.time.LocalDate
+
+@Entity
+@Table(name = "daily_study_sets")
+data class DailyStudySetEntity(
+    val userId: Long,
+    @Column(columnDefinition = "bigint[]", nullable = false, updatable = true, name = "study_ids")
+    @Type(ListArrayType::class)
+    val studyIds: List<Long>,
+    val date: LocalDate,
+) : BaseEntity() {
+    fun toDomain(): DailyStudySet {
+        return DailyStudySet(
+            id = id ?: throw InOutRequireNotNullException("DailyStudySet id is null", "IORNN_DAILY_STUDY_SET_1"),
+            userId = userId,
+            studyIds = studyIds,
+            date = date,
+        )
+    }
+
+    companion object {
+        fun fromCreateObject(dailyStudySetCreateObject: DailyStudySetCreateObject): DailyStudySetEntity {
+            return DailyStudySetEntity(
+                userId = dailyStudySetCreateObject.userId,
+                studyIds = emptyList(),
+                date = dailyStudySetCreateObject.date,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetJpaRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.inout.apiserver.infrastructure.db.study
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface DailyStudySetJpaRepository : JpaRepository<DailyStudySetEntity, Long> {
+    fun findByUserIdAndDate(
+        userId: Long,
+        date: LocalDate,
+    ): DailyStudySetEntity?
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetRepository.kt
@@ -1,0 +1,21 @@
+package com.inout.apiserver.infrastructure.db.study
+
+import com.inout.apiserver.domain.study.DailyStudySet
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class DailyStudySetRepository(
+    private val dailyStudySetJpaRepository: DailyStudySetJpaRepository,
+) {
+    fun save(dailyStudySet: DailyStudySetEntity): DailyStudySet {
+        return dailyStudySetJpaRepository.save(dailyStudySet).toDomain()
+    }
+
+    fun findByUserIdAndDate(
+        userId: Long,
+        date: LocalDate,
+    ): DailyStudySet? {
+        return dailyStudySetJpaRepository.findByUserIdAndDate(userId, date)?.toDomain()
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyJpaRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyJpaRepository.kt
@@ -3,6 +3,7 @@ package com.inout.apiserver.infrastructure.db.study
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.Instant
 
 interface StudyJpaRepository : JpaRepository<StudyEntity, Long> {
     fun findByUserIdAndWordDefinitionId(
@@ -13,5 +14,11 @@ interface StudyJpaRepository : JpaRepository<StudyEntity, Long> {
     fun findAllByUserId(
         userId: Long,
         sortIgnoredPageRequest: Pageable,
+    ): Page<StudyEntity>
+
+    fun findAllByUserIdAndDueLessThanOrderByDue(
+        userId: Long,
+        due: Instant,
+        pageable: Pageable,
     ): Page<StudyEntity>
 }

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepository.kt
@@ -4,6 +4,7 @@ import com.inout.apiserver.domain.study.Study
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import java.time.Instant
 
 @Repository
 class StudyRepository(
@@ -29,5 +30,18 @@ class StudyRepository(
         pageable: Pageable,
     ): Page<Study> {
         return studyJpaRepository.findAllByUserId(userId, pageable).map { it.toDomain() }
+    }
+
+    fun findAllByIds(ids: List<Long>): List<Study> {
+        return studyJpaRepository.findAllById(ids).map { it.toDomain() }
+    }
+
+    fun findAllPastDueStudiesBy(
+        userId: Long,
+        due: Instant,
+        pageable: Pageable,
+    ): Page<Study> {
+        return studyJpaRepository.findAllByUserIdAndDueLessThanOrderByDue(userId, due, pageable)
+            .map { it.toDomain() }
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/StudyController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/StudyController.kt
@@ -15,7 +15,6 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -54,8 +53,7 @@ class StudyController(
         )
     }
 
-    @GetMapping("/daily")
-    fun getDailyStudySet(
+    override fun getDailyStudySet(
         @Parameter(hidden = true) @RequestUser user: User,
         @RequestParam(name = "date", required = true) date: LocalDate,
     ): ResponseEntity<DailyStudySetResponse> {

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/StudyController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/StudyController.kt
@@ -1,11 +1,13 @@
 package com.inout.apiserver.interfaces.web.v1
 
 import com.inout.apiserver.application.study.CreateStudyApplication
+import com.inout.apiserver.application.study.ReadOrCreateDailyStudySetApplication
 import com.inout.apiserver.application.study.ReadStudiesApplication
 import com.inout.apiserver.config.web.RequestUser
 import com.inout.apiserver.domain.user.User
 import com.inout.apiserver.interfaces.web.v1.apiSpec.StudyApiSpec
 import com.inout.apiserver.interfaces.web.v1.request.CreateStudyRequest
+import com.inout.apiserver.interfaces.web.v1.response.DailyStudySetResponse
 import com.inout.apiserver.interfaces.web.v1.response.ResponsePaginationWrapper
 import com.inout.apiserver.interfaces.web.v1.response.StudyWordResponse
 import io.swagger.v3.oas.annotations.Parameter
@@ -13,15 +15,19 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/v1/studies")
 class StudyController(
     private val createStudyApplication: CreateStudyApplication,
     private val readStudiesApplication: ReadStudiesApplication,
+    private val readOrCreateDailyStudySetApplication: ReadOrCreateDailyStudySetApplication,
 ) : StudyApiSpec {
     override fun createStudy(
         @RequestBody @Valid request: CreateStudyRequest,
@@ -44,6 +50,18 @@ class StudyController(
                 hasMore = pageable.next().offset < count,
                 count = count,
             ),
+            HttpStatus.OK,
+        )
+    }
+
+    @GetMapping("/daily")
+    fun getDailyStudySet(
+        @Parameter(hidden = true) @RequestUser user: User,
+        @RequestParam(name = "date", required = true) date: LocalDate,
+    ): ResponseEntity<DailyStudySetResponse> {
+        val dailyStudySetResult = readOrCreateDailyStudySetApplication.run(user.id, date)
+        return ResponseEntity(
+            DailyStudySetResponse.of(dailyStudySetResult.dailyStudySet.date, dailyStudySetResult.studyWords),
             HttpStatus.OK,
         )
     }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/apiSpec/StudyApiSpec.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/apiSpec/StudyApiSpec.kt
@@ -3,6 +3,7 @@ package com.inout.apiserver.interfaces.web.v1.apiSpec
 import com.inout.apiserver.domain.user.User
 import com.inout.apiserver.error.HttpException
 import com.inout.apiserver.interfaces.web.v1.request.CreateStudyRequest
+import com.inout.apiserver.interfaces.web.v1.response.DailyStudySetResponse
 import com.inout.apiserver.interfaces.web.v1.response.ResponsePaginationWrapper
 import com.inout.apiserver.interfaces.web.v1.response.StudyWordResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import java.time.LocalDate
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 
 interface StudyApiSpec {
@@ -88,4 +90,34 @@ interface StudyApiSpec {
         @Parameter(hidden = true) user: User,
         @Parameter(hidden = true) pageable: Pageable,
     ): ResponseEntity<ResponsePaginationWrapper<StudyWordResponse>>
+
+    @GetMapping("/daily")
+    @Operation(
+        summary = "일일 학습셋 조회",
+        description = "요청자의 일일 학습셋을 조회합니다.",
+        parameters = [
+            Parameter(
+                name = "date",
+                description = "조회할 일자",
+                required = true,
+                example = "2024-09-29",
+            ),
+        ],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "일일 학습 진행 상황 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = DailyStudySetResponse::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getDailyStudySet(
+        @Parameter(hidden = true) user: User,
+        @Parameter(name = "date", required = true) date: LocalDate,
+    ): ResponseEntity<DailyStudySetResponse>
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/DailyStudySetResponse.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/DailyStudySetResponse.kt
@@ -1,0 +1,21 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+import com.inout.apiserver.domain.study.StudyWord
+import java.time.LocalDate
+
+data class DailyStudySetResponse(
+    val date: LocalDate,
+    val studies: List<StudyWordResponse>,
+) {
+    companion object {
+        fun of(
+            date: LocalDate,
+            studies: List<StudyWord>,
+        ): DailyStudySetResponse {
+            return DailyStudySetResponse(
+                date = date,
+                studies = studies.map { StudyWordResponse.of(study = it.study, word = it.word) },
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplicationTest.kt
@@ -1,0 +1,151 @@
+package com.inout.apiserver.application.study
+
+import com.inout.apiserver.domain.study.DailyStudySet
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.study.StudyService
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.error.NotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ReadOrCreateDailyStudySetApplicationTest {
+    private val studyService = mockk<StudyService>()
+    private val wordService = mockk<WordService>()
+    private val readOrCreateDailyStudySetApplication = ReadOrCreateDailyStudySetApplication(studyService, wordService)
+
+    private fun mockStudyServiceGetDailyStudySetNull() {
+        every { studyService.getDailyStudySet(any(), any()) } returns null
+    }
+
+    private fun mockCreateEmptyDailyStudySet() {
+        every { studyService.getStudiesByIds(any()) } returns emptyList()
+        every { studyService.getStudiesPastDue(any(), any(), any()) } returns listOf(StudyFactory.createStudy())
+        every { wordService.getWordsByWordDefinitionIds(any()) } returns listOf(WordFactory.createWord())
+        every { studyService.createDailyStudySet(any()) } returns
+            DailyStudySet(
+                id = 1L,
+                userId = 1L,
+                date = LocalDate.now(),
+                studyIds = emptyList(),
+            )
+    }
+
+    private fun mockStudyServiceGetDailyStudySet() {
+        every { studyService.getDailyStudySet(any(), any()) } returns
+            DailyStudySet(
+                id = 1L,
+                userId = 1L,
+                date = LocalDate.now(),
+                studyIds = listOf(1L),
+            )
+        every { studyService.getStudiesByIds(any()) } returns listOf(StudyFactory.createStudy())
+        every { wordService.getWordsByWordDefinitionIds(any()) } returns listOf(WordFactory.createWord())
+    }
+
+    @Test
+    fun `if provided date is after today, then throw BadRequestException`() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now().plusDays(1)
+
+        // when
+        val exception =
+            assertThrows(BadRequestException::class.java) {
+                readOrCreateDailyStudySetApplication.run(userId, date)
+            }
+
+        // then
+        assertEquals("Cannot request future daily study set", exception.message)
+        assertEquals("STUDY_3", exception.code)
+    }
+
+    @Test
+    fun `if provided date is not today but dailyStudySet is null, then throw NotFoundException`() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now().minusDays(1)
+        mockStudyServiceGetDailyStudySetNull()
+
+        // when
+        val exception =
+            assertThrows(NotFoundException::class.java) {
+                readOrCreateDailyStudySetApplication.run(userId, date)
+            }
+
+        // then
+        assertEquals("DailyStudySet not found", exception.message)
+        assertEquals("STUDY_4", exception.code)
+        verify(exactly = 1) { studyService.getDailyStudySet(userId, date) }
+    }
+
+    @Test
+    fun `should create dailyStudySet if it does not exist`() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now()
+        mockStudyServiceGetDailyStudySetNull()
+        mockCreateEmptyDailyStudySet()
+
+        // when
+        readOrCreateDailyStudySetApplication.run(userId, date)
+
+        // then
+        verify(exactly = 1) { studyService.createDailyStudySet(any()) }
+    }
+
+    @Test
+    fun `returned dailyStudySet should have studyIds of target studies`() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now()
+        mockStudyServiceGetDailyStudySetNull()
+        mockCreateEmptyDailyStudySet()
+
+        // when
+        val result = readOrCreateDailyStudySetApplication.run(userId, date)
+
+        // then
+        assertEquals(1, result.dailyStudySet.studyIds.size)
+        assertEquals(1L, result.dailyStudySet.studyIds[0])
+    }
+
+    @Test
+    fun `returned studyWords should return target study words`() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now()
+        mockStudyServiceGetDailyStudySetNull()
+        mockCreateEmptyDailyStudySet()
+
+        // when
+        val result = readOrCreateDailyStudySetApplication.run(userId, date)
+
+        // then
+        assertEquals(1, result.studyWords.size)
+        assertEquals(1L, result.studyWords[0].study.id)
+    }
+
+    @Test
+    fun `should return past dailyStudySet if it exists`() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now().minusDays(1)
+        mockStudyServiceGetDailyStudySet()
+
+        // when
+        val result = readOrCreateDailyStudySetApplication.run(userId, date)
+
+        // then
+        assertEquals(1, result.dailyStudySet.studyIds.size)
+        assertEquals(1L, result.dailyStudySet.studyIds[0])
+        assertEquals(1, result.studyWords.size)
+        assertEquals(1L, result.studyWords[0].study.id)
+    }
+}

--- a/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyFactory.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyFactory.kt
@@ -1,0 +1,43 @@
+package com.inout.apiserver.domain.study
+
+import com.inout.apiserver.base.enums.FsrsCardState
+import java.time.Instant
+
+class StudyFactory {
+    companion object {
+        fun createStudy(
+            id: Long = 1L,
+            userId: Long = 1L,
+            wordDefinitionId: Long = 1L,
+            state: FsrsCardState = FsrsCardState.NEW,
+            due: Instant = Instant.now(),
+            stability: Double = 0.0,
+            difficulty: Double = 0.0,
+            elapsedDays: Int = 0,
+            scheduledDays: Int = 0,
+            reps: Int = 0,
+            lapses: Int = 0,
+            lastReview: Instant? = null,
+            reviewLogs: List<StudyReviewLog> = emptyList(),
+        ): Study {
+            val now = Instant.now()
+            return Study(
+                id = id,
+                userId = userId,
+                wordDefinitionId = wordDefinitionId,
+                state = state,
+                due = due,
+                stability = stability,
+                difficulty = difficulty,
+                elapsedDays = elapsedDays,
+                scheduledDays = scheduledDays,
+                reps = reps,
+                lapses = lapses,
+                lastReview = lastReview,
+                reviewLogs = reviewLogs,
+                createdAt = now,
+                updatedAt = now,
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyServiceTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyServiceTest.kt
@@ -2,6 +2,7 @@ package com.inout.apiserver.domain.study
 
 import com.inout.apiserver.base.enums.FsrsCardState
 import com.inout.apiserver.error.ConflictException
+import com.inout.apiserver.infrastructure.db.study.DailyStudySetRepository
 import com.inout.apiserver.infrastructure.db.study.StudyRepository
 import com.inout.fsrs.model.Card
 import io.mockk.every
@@ -16,10 +17,13 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 class StudyServiceTest {
     private val studyRepository = mockk<StudyRepository>()
-    private val studyService = StudyService(studyRepository)
+    private val dailyStudySetRepository = mockk<DailyStudySetRepository>()
+    private val studyService = StudyService(studyRepository, dailyStudySetRepository)
     private val now = Instant.now()
 
     private fun createStudies(count: Int): List<Study> {
@@ -43,6 +47,15 @@ class StudyServiceTest {
                 updatedAt = now,
             )
         }
+    }
+
+    private fun createDailyStudySet(
+        userId: Long,
+        date: Instant,
+        studyIds: List<Long>,
+    ): DailyStudySet {
+        val localDate = LocalDate.ofInstant(date, date.atZone(ZoneId.systemDefault()).offset)
+        return DailyStudySet(id = 1L, userId = userId, studyIds = studyIds, date = localDate)
     }
 
     @Nested
@@ -174,6 +187,136 @@ class StudyServiceTest {
             assertEquals(1L, sut.wordDefinitionId)
             assertEquals(now, sut.createdAt)
             assertEquals(now, sut.updatedAt)
+        }
+    }
+
+    @Nested
+    inner class GetStudiesPastDue {
+        @Test
+        fun `should return empty list when count is 0 or less`() {
+            listOf(0, -1).forEach { count ->
+                // when
+                val sut = studyService.getStudiesPastDue(1L, now, count)
+
+                // then
+                assertTrue(sut.isEmpty())
+            }
+        }
+
+        @Test
+        fun `should return list of studies`() {
+            // given
+            val studies = createStudies(3)
+            every { studyRepository.findAllPastDueStudiesBy(1L, now, any()) } returns PageImpl(studies)
+
+            // when
+            val sut = studyService.getStudiesPastDue(1L, now, 3)
+
+            // then
+            assertEquals(3, sut.size)
+            assertEquals(studies, sut)
+        }
+    }
+
+    @Nested
+    inner class GetStudiesByIds {
+        @Test
+        fun `should return empty list when ids is empty`() {
+            // given
+            every { studyRepository.findAllByIds(emptyList()) } returns emptyList()
+
+            // when
+            val sut = studyService.getStudiesByIds(emptyList())
+
+            // then
+            assertTrue(sut.isEmpty())
+        }
+
+        @Test
+        fun `should return list of studies`() {
+            // given
+            val studies = createStudies(3)
+            val ids = studies.map { it.id!! }
+            every { studyRepository.findAllByIds(ids) } returns studies
+
+            // when
+            val sut = studyService.getStudiesByIds(ids)
+
+            // then
+            assertEquals(3, sut.size)
+            assertEquals(studies, sut)
+        }
+    }
+
+    @Nested
+    inner class GetDailyStudySet {
+        @Test
+        fun `should return null when daily study set does not exist`() {
+            // given
+            every { dailyStudySetRepository.findByUserIdAndDate(1L, any()) } returns null
+
+            // when
+            val sut = studyService.getDailyStudySet(1L, LocalDate.now())
+
+            // then
+            assertNull(sut)
+        }
+
+        @Test
+        fun `should return daily study set when it exists`() {
+            // given
+            val dailyStudySet = createDailyStudySet(1L, now, listOf(1L, 2L))
+            every { dailyStudySetRepository.findByUserIdAndDate(1L, any()) } returns dailyStudySet
+
+            // when
+            val sut = studyService.getDailyStudySet(1L, LocalDate.now())
+
+            // then
+            assertEquals(dailyStudySet, sut)
+        }
+    }
+
+    @Nested
+    inner class CreateDailyStudySet {
+        @Test
+        fun `should throw ConflictException when daily study set already exists`() {
+            // given
+            val dailyStudySetCreateObject =
+                DailyStudySetCreateObject(
+                    userId = 1L,
+                    date = LocalDate.now(),
+                )
+            every { dailyStudySetRepository.findByUserIdAndDate(1L, any()) } returns
+                createDailyStudySet(1L, now, listOf(1L, 2L))
+
+            // when
+            val exception =
+                assertThrows(ConflictException::class.java) {
+                    studyService.createDailyStudySet(dailyStudySetCreateObject)
+                }
+
+            // then
+            assertEquals("Daily study set already exists", exception.message)
+            assertEquals("STUDY_5", exception.code)
+        }
+
+        @Test
+        fun `should create daily study set when it does not exist`() {
+            // given
+            val dailyStudySetCreateObject =
+                DailyStudySetCreateObject(
+                    userId = 1L,
+                    date = LocalDate.now(),
+                )
+            every { dailyStudySetRepository.findByUserIdAndDate(1L, any()) } returns null
+            val dailyStudySet = createDailyStudySet(1L, now, listOf(1L, 2L))
+            every { dailyStudySetRepository.save(any()) } returns dailyStudySet
+
+            // when
+            val sut = studyService.createDailyStudySet(dailyStudySetCreateObject)
+
+            // then
+            assertEquals(dailyStudySet, sut)
         }
     }
 }

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
@@ -1,0 +1,37 @@
+package com.inout.apiserver.domain.word
+
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import java.time.Instant
+
+class WordFactory {
+    companion object {
+        fun createWord(
+            id: Long = 1L,
+            name: String = "book",
+            fromLanguage: LanguageType = LanguageType.ENGLISH,
+            toLanguage: LanguageType = LanguageType.KOREAN,
+            lexicalCategory: LexicalCategoryType = LexicalCategoryType.NOUN,
+            meaning: String = "책",
+            preContext: String = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+        ): Word {
+            val now = Instant.now()
+            val wordDefinition =
+                WordDefinition(
+                    id = id,
+                    lexicalCategory = lexicalCategory,
+                    meaning = meaning,
+                    preContext = preContext,
+                )
+            return Word(
+                id = id,
+                name = name,
+                fromLanguage = fromLanguage,
+                toLanguage = toLanguage,
+                definitions = listOf(wordDefinition),
+                createdAt = now,
+                updatedAt = now,
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/inout/apiserver/infrastructure/db/DbCleanUp.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/infrastructure/db/DbCleanUp.kt
@@ -26,11 +26,8 @@ class DbCleanUp(
     @Transactional
     fun execute() {
         em.flush()
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate() // set foreign key checks off
-        tableNames.forEach {
-            em.createNativeQuery("TRUNCATE TABLE %s".format(it)).executeUpdate()
-            em.createNativeQuery("ALTER TABLE %s ALTER COLUMN id RESTART WITH 1".format(it)).executeUpdate()
+        tableNames.forEach { tableName ->
+            em.createNativeQuery("TRUNCATE TABLE $tableName RESTART IDENTITY CASCADE").executeUpdate()
         }
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate() // set foreign key checks on
     }
 }

--- a/app/src/test/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetRepositoryTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/infrastructure/db/study/DailyStudySetRepositoryTest.kt
@@ -1,0 +1,100 @@
+package com.inout.apiserver.infrastructure.db.study
+
+import com.inout.apiserver.domain.study.DailyStudySetCreateObject
+import com.inout.apiserver.infrastructure.db.DbTestSupport
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.Import
+import java.time.LocalDate
+
+@Import(DailyStudySetRepository::class)
+class DailyStudySetRepositoryTest(
+    private val dailyStudySetRepository: DailyStudySetRepository,
+    private val dailyStudySetJpaRepository: DailyStudySetJpaRepository,
+) : DbTestSupport() {
+    private fun createUnsavedDailyStudySetEntity(
+        userId: Long,
+        date: LocalDate,
+    ): DailyStudySetEntity {
+        return DailyStudySetEntity.fromCreateObject(
+            DailyStudySetCreateObject(
+                userId = userId,
+                date = date,
+            ),
+        )
+    }
+
+    @Nested
+    inner class Save {
+        @Test
+        fun `should save daily study set entity`() {
+            // given
+            val userId = 1L
+            val date = LocalDate.now()
+            val dailyStudySetEntity = createUnsavedDailyStudySetEntity(userId, date)
+
+            // when
+            val sut = dailyStudySetRepository.save(dailyStudySetEntity)
+
+            // then
+            assertNotNull(sut.id)
+            assertEquals(userId, sut.userId)
+            assertEquals(date, sut.date)
+            assertEquals(0, sut.studyIds.size)
+        }
+
+        @Test
+        fun `should raise error when same user and date exists`() {
+            // given
+            val userId = 1L
+            val date = LocalDate.now()
+            val dailyStudySetEntity = createUnsavedDailyStudySetEntity(userId, date)
+            dailyStudySetJpaRepository.save(dailyStudySetEntity)
+
+            // when
+            val sut = createUnsavedDailyStudySetEntity(userId, date)
+
+            // then
+            assertThatThrownBy { dailyStudySetRepository.save(sut) }
+                .isInstanceOf(Exception::class.java)
+                .hasMessageContaining("could not execute statement")
+        }
+    }
+
+    @Nested
+    inner class FindByUserIdAndDate {
+        @Test
+        fun `should find daily study set entity by user id and date`() {
+            // given
+            val userId = 1L
+            val date = LocalDate.now()
+            val dailyStudySetEntity = createUnsavedDailyStudySetEntity(userId, date)
+            dailyStudySetJpaRepository.save(dailyStudySetEntity)
+
+            // when
+            val sut = dailyStudySetRepository.findByUserIdAndDate(userId, date)!!
+
+            // then
+            assertEquals(userId, sut.userId)
+            assertEquals(date, sut.date)
+            assertEquals(0, sut.studyIds.size)
+        }
+
+        @Test
+        fun `should return null when daily study set entity not found by user id and date`() {
+            // given
+            val userId = 1L
+            val date = LocalDate.now()
+
+            // when
+            val sut = dailyStudySetRepository.findByUserIdAndDate(userId, date)
+
+            // then
+            assertNull(sut)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepositoryTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepositoryTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
+import java.time.Instant
 
 @Import(StudyRepository::class)
 class StudyRepositoryTest(
@@ -149,6 +150,89 @@ class StudyRepositoryTest(
             val sut1 = studyRepository.findAllByUserId(userId, pageable1)
             val pageable2 = PageRequest.of(1, 6)
             val sut2 = studyRepository.findAllByUserId(userId, pageable2)
+
+            // then
+            assertEquals(10, sut1.totalElements)
+            assertEquals(6, sut1.numberOfElements)
+            assertEquals(6, sut1.content.size)
+            assertEquals(true, sut1.hasNext())
+
+            assertEquals(10, sut2.totalElements)
+            assertEquals(4, sut2.numberOfElements)
+            assertEquals(4, sut2.content.size)
+            assertEquals(false, sut2.hasNext())
+        }
+    }
+
+    @Nested
+    inner class FindAllByIds {
+        @Test
+        fun `should return empty list when study entity not exists`() {
+            // given
+            val ids = emptyList<Long>()
+
+            // when
+            val sut = studyRepository.findAllByIds(ids)
+
+            // then
+            assertTrue(sut.isEmpty())
+        }
+
+        @Test
+        fun `should return list of study entity`() {
+            // given
+            val userId = 1L
+            val studies = (1..10).map { createUnsavedStudyEntity(userId, it.toLong()) }
+            val savedStudies = studyJpaRepository.saveAll(studies)
+
+            // when
+            val ids = savedStudies.shuffled().take(5).map { it.id!! }
+            val sut = studyRepository.findAllByIds(ids)
+
+            // then
+            assertEquals(5, sut.size)
+            sut.forEach { study ->
+                assertTrue(ids.contains(study.id))
+            }
+        }
+    }
+
+    @Nested
+    inner class FindAllPastDueStudiesBy {
+        @Test
+        fun `should return empty page when study entity not exists`() {
+            // given
+            val userId = 1L
+            val savedStudies = (1..10).map { createUnsavedStudyEntity(userId, it.toLong()) }
+            studyJpaRepository.saveAll(savedStudies)
+            val due = Instant.now()
+            val studies = (11..20).map { createUnsavedStudyEntity(userId, it.toLong()) }
+            studyJpaRepository.saveAll(studies)
+
+            // when
+            val pageable = PageRequest.of(0, 10)
+            val sut = studyRepository.findAllPastDueStudiesBy(userId, due, pageable)
+
+            // then
+            assertEquals(10, sut.totalElements)
+            assertEquals(10, sut.numberOfElements)
+            assertEquals(10, sut.content.size)
+            assertEquals(false, sut.hasNext())
+        }
+
+        @Test
+        fun `should return page of study entity`() {
+            // given
+            val userId = 1L
+            val studies = (1..10).map { createUnsavedStudyEntity(userId, it.toLong()) }
+            studyJpaRepository.saveAll(studies)
+
+            // when
+            val due = Instant.now()
+            val pageable1 = PageRequest.of(0, 6)
+            val sut1 = studyRepository.findAllPastDueStudiesBy(userId, due, pageable1)
+            val pageable2 = PageRequest.of(1, 6)
+            val sut2 = studyRepository.findAllPastDueStudiesBy(userId, due, pageable2)
 
             // then
             assertEquals(10, sut1.totalElements)

--- a/app/src/test/resources/application.yml
+++ b/app/src/test/resources/application.yml
@@ -11,6 +11,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        jdbc:
+          time_zone: UTC
 jwt:
   key: "test-super-long-secret-key-1234567890"
   access-token-expiration: 60000000

--- a/app/src/test/resources/application.yml
+++ b/app/src/test/resources/application.yml
@@ -1,16 +1,16 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:postgresql://localhost:5432/test
+    driver-class-name: org.postgresql.Driver
+    username: admin
+    password: inout1234
   jpa:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 jwt:
   key: "test-super-long-secret-key-1234567890"
   access-token-expiration: 60000000


### PR DESCRIPTION
- add hypersistence-utils dependency to resolve postgres' jsonb/array type
- create DailyStudySet subdomain which holds user's study set information on a daily basis
- create daily set read flow
- add exception handling for MethodArgumentTypeMismatch (ex. date provided like "2024-09-290" which is invalid and treated as string)
- replace postgres for test db as bigint[] is not supported by h2
- add missing validation for creating daily study set (conflict)
  - add relevant unique constraint
- add timezone settings for spring application including test env
- add tests
- add api spec for swagger

https://inoutedu.atlassian.net/browse/IO-15