### PR TITLE
feature: Add conversation domain

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("com.google.api-client:google-api-client:2.2.0")
 
     // aws
+    // TODO: aws-java-sdk 1.x entered maintenance mode and support ends on Dec 31, 2025
     implementation("com.amazonaws:aws-java-sdk-s3:1.12.780")
 
     // test

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/GetConversationsApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/GetConversationsApplication.kt
@@ -1,0 +1,36 @@
+package com.inout.apiserver.application.word
+
+import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.domain.study.StudyService
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.infrastructure.db.word.Conversation
+import org.springframework.stereotype.Component
+
+@Component
+class GetConversationsApplication(
+    private val studyService: StudyService,
+    private val wordService: WordService,
+) {
+    data class Request(
+        val wordDefinitionId: WordDefinitionId,
+        val user: User,
+    )
+
+    data class Response(
+        val conversations: List<Conversation>,
+    )
+
+    fun run(request: Request): Response {
+        studyService.getByUserIdAndWordDefinitionId(request.user.id!!, request.wordDefinitionId)
+            ?: throw BadRequestException(
+                message = "User is not studying given wordDefinitionId of ${request.wordDefinitionId}",
+                code = "CONVERSATION_1",
+            )
+
+        return Response(
+            conversations = wordService.getConversationsBy(request.user, request.wordDefinitionId),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/SelectReadingSentenceApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/SelectReadingSentenceApplication.kt
@@ -28,6 +28,7 @@ class SelectReadingSentenceApplication(
     )
 
     fun run(request: Request): Response {
+        // FIXME: user needs to be studying given sentence
         val sentence =
             wordService.getSentenceByIdAndType(request.sentenceId, SentenceType.READING) ?: throw NotFoundException(
                 message = "Sentence Not Found",

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/StartConversationApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/StartConversationApplication.kt
@@ -1,9 +1,11 @@
 package com.inout.apiserver.application.word
 
 import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.SenderType
 import com.inout.apiserver.domain.study.StudyService
 import com.inout.apiserver.domain.word.ConversationCreateObject
+import com.inout.apiserver.domain.word.WordAIService
 import com.inout.apiserver.domain.word.WordService
 import com.inout.apiserver.error.BadRequestException
 import com.inout.apiserver.infrastructure.db.user.User
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component
 class StartConversationApplication(
     private val wordService: WordService,
     private val studyService: StudyService,
+    private val wordAIService: WordAIService,
 ) {
     companion object {
         private const val MAX_CONVERSATION_COUNT = 3
@@ -46,11 +49,23 @@ class StartConversationApplication(
                     )
                 }
 
-                // TODO: need initial system message
+                val word = wordService.getWordByWordDefinitionId(request.wordDefinitionId)
+                val audio =
+                    wordAIService.findOrCreateAudio(
+                        language = word.fromLanguage,
+                        content =
+                            when (word.fromLanguage) { // TODO: create a separate class responsible for generating initial conversation
+                                LanguageType.ENGLISH -> "Let's talk about ${word.name}!"
+                                LanguageType.KOREAN -> "${word.name}에 대해 이야기 해볼까요?"
+                            },
+                    )
+
                 wordService.createConversation(
                     ConversationCreateObject(
                         userId = request.user.id!!,
                         wordDefinitionId = request.wordDefinitionId,
+                        systemMessage = audio.content,
+                        systemAudio = audio,
                     ),
                 )
             }

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/StartConversationApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/StartConversationApplication.kt
@@ -1,0 +1,60 @@
+package com.inout.apiserver.application.word
+
+import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.base.enums.SenderType
+import com.inout.apiserver.domain.study.StudyService
+import com.inout.apiserver.domain.word.ConversationCreateObject
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.infrastructure.db.word.Conversation
+import org.springframework.stereotype.Component
+
+@Component
+class StartConversationApplication(
+    private val wordService: WordService,
+    private val studyService: StudyService,
+) {
+    companion object {
+        private const val MAX_CONVERSATION_COUNT = 3
+    }
+
+    data class Request(
+        val wordDefinitionId: WordDefinitionId,
+        val user: User,
+    )
+
+    data class Response(
+        val conversation: Conversation,
+    )
+
+    fun run(request: Request): Response {
+        studyService.getByUserIdAndWordDefinitionId(request.user.id!!, request.wordDefinitionId)
+            ?: throw BadRequestException(
+                message = "User is not studying given wordDefinitionId of ${request.wordDefinitionId}",
+                code = "CONVERSATION_1",
+            )
+        val conversations = wordService.getConversationsBy(request.user, request.wordDefinitionId)
+        val conversation =
+            conversations.firstOrNull { conversation ->
+                conversation.messages.count { it.sender == SenderType.USER } == 0
+            } ?: run {
+                if (conversations.size >= MAX_CONVERSATION_COUNT) {
+                    throw BadRequestException(
+                        message = "Reached maximum number of conversations",
+                        code = "CONVERSATION_2",
+                    )
+                }
+
+                // TODO: need initial system message
+                wordService.createConversation(
+                    ConversationCreateObject(
+                        userId = request.user.id!!,
+                        wordDefinitionId = request.wordDefinitionId,
+                    ),
+                )
+            }
+
+        return Response(conversation)
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/base/alias/AiAudioId.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/alias/AiAudioId.kt
@@ -1,0 +1,3 @@
+package com.inout.apiserver.base.alias
+
+typealias AiAudioId = Long

--- a/app/src/main/kotlin/com/inout/apiserver/base/alias/ConversationId.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/alias/ConversationId.kt
@@ -1,0 +1,3 @@
+package com.inout.apiserver.base.alias
+
+typealias ConversationId = Long

--- a/app/src/main/kotlin/com/inout/apiserver/base/alias/ConversationMessageId.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/alias/ConversationMessageId.kt
@@ -1,0 +1,3 @@
+package com.inout.apiserver.base.alias
+
+typealias ConversationMessageId = Long

--- a/app/src/main/kotlin/com/inout/apiserver/base/enums/AiVoiceType.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/enums/AiVoiceType.kt
@@ -1,5 +1,14 @@
 package com.inout.apiserver.base.enums
 
+import com.aallam.openai.api.audio.Voice
+
 enum class AiVoiceType {
     ALLOY,
+    ;
+
+    fun toOpenAIVoice() =
+        when (this) {
+            ALLOY -> Voice.Alloy
+            else -> throw IllegalArgumentException("Unknown OpenAI voice type: $this")
+        }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/base/enums/AiVoiceType.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/enums/AiVoiceType.kt
@@ -1,0 +1,5 @@
+package com.inout.apiserver.base.enums
+
+enum class AiVoiceType {
+    ALLOY,
+}

--- a/app/src/main/kotlin/com/inout/apiserver/base/enums/SenderType.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/enums/SenderType.kt
@@ -1,0 +1,6 @@
+package com.inout.apiserver.base.enums
+
+enum class SenderType {
+    USER,
+    SYSTEM,
+}

--- a/app/src/main/kotlin/com/inout/apiserver/base/serializer/PreSignedUrlSerializer.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/serializer/PreSignedUrlSerializer.kt
@@ -1,0 +1,19 @@
+package com.inout.apiserver.base.serializer
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.inout.apiserver.infrastructure.s3.S3Service
+
+class PreSignedUrlSerializer(
+    private val s3Service: S3Service,
+) : JsonSerializer<String?>() {
+    override fun serialize(
+        value: String?,
+        gen: JsonGenerator,
+        serializers: SerializerProvider,
+    ) {
+        val url = value?.let { s3Service.getAudioUrl(it) }
+        gen.writeString(url)
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/base/service/openai/OpenAIService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/service/openai/OpenAIService.kt
@@ -2,6 +2,7 @@ package com.inout.apiserver.base.service.openai
 
 import com.aallam.openai.api.chat.TextContent
 import com.aallam.openai.client.OpenAI
+import com.inout.apiserver.base.enums.AiVoiceType
 import com.inout.apiserver.base.service.openai.dto.OpenAIWordDefinitionResponse
 import com.inout.apiserver.base.service.openai.dto.OpenAIWordDefinitionSentenceResponse
 import com.inout.apiserver.base.service.openai.dto.OpenAIWritingSentenceFeedbackResponse
@@ -115,5 +116,13 @@ class OpenAIService(
         val transcriptionRequest = openAIRequestProvider.genTranscriptionRequest(file, language)
         val transcription = runBlocking { openai.transcription(transcriptionRequest) }
         return transcription.text
+    }
+
+    fun fetchSpeechFromText(
+        text: String,
+        aiVoiceType: AiVoiceType = AiVoiceType.ALLOY,
+    ): ByteArray {
+        val speechRequest = openAIRequestProvider.genSpeechRequest(text, aiVoiceType)
+        return runBlocking { openai.speech(speechRequest) }
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/base/service/openai/provider/OpenAIRequestProvider.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/service/openai/provider/OpenAIRequestProvider.kt
@@ -1,6 +1,8 @@
 package com.inout.apiserver.base.service.openai.provider
 
 import com.aallam.openai.api.audio.AudioResponseFormat
+import com.aallam.openai.api.audio.SpeechRequest
+import com.aallam.openai.api.audio.SpeechResponseFormat
 import com.aallam.openai.api.audio.TranscriptionRequest
 import com.aallam.openai.api.chat.ChatCompletionRequest
 import com.aallam.openai.api.chat.ChatMessage
@@ -8,6 +10,7 @@ import com.aallam.openai.api.chat.ChatResponseFormat
 import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.file.FileSource
 import com.aallam.openai.api.model.ModelId
+import com.inout.apiserver.base.enums.AiVoiceType
 import com.inout.apiserver.error.BadRequestException
 import okio.source
 import org.springframework.stereotype.Component
@@ -19,6 +22,8 @@ class OpenAIRequestProvider {
     private val chatCompletionResponseFormat = ChatResponseFormat.JsonObject
     private val transcriptionModel = ModelId("whisper-1")
     private val transcriptionResponseFormat = AudioResponseFormat.Text
+    private val speechModel = ModelId("tts-1")
+    private val speechResponseFormat = SpeechResponseFormat.Mp3
 
     fun genWordInfoRequest(
         word: String,
@@ -217,4 +222,14 @@ class OpenAIRequestProvider {
             responseFormat = transcriptionResponseFormat,
         )
     }
+
+    fun genSpeechRequest(
+        text: String,
+        voiceType: AiVoiceType,
+    ) = SpeechRequest(
+        model = speechModel,
+        input = text,
+        voice = voiceType.toOpenAIVoice(),
+        responseFormat = speechResponseFormat,
+    )
 }

--- a/app/src/main/kotlin/com/inout/apiserver/base/service/openai/provider/OpenAIRequestProvider.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/service/openai/provider/OpenAIRequestProvider.kt
@@ -231,5 +231,6 @@ class OpenAIRequestProvider {
         input = text,
         voice = voiceType.toOpenAIVoice(),
         responseFormat = speechResponseFormat,
+        speed = 0.90,
     )
 }

--- a/app/src/main/kotlin/com/inout/apiserver/config/web/JacksonConfig.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/config/web/JacksonConfig.kt
@@ -1,0 +1,14 @@
+package com.inout.apiserver.config.web
+
+import com.inout.apiserver.base.serializer.PreSignedUrlSerializer
+import com.inout.apiserver.infrastructure.s3.S3Service
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JacksonConfig(
+    private val s3Service: S3Service,
+) {
+    @Bean
+    fun preSignedUrlSerializer() = PreSignedUrlSerializer(s3Service)
+}

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/AiAudioCreateObject.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/AiAudioCreateObject.kt
@@ -1,0 +1,11 @@
+package com.inout.apiserver.domain.word
+
+import com.inout.apiserver.base.enums.AiVoiceType
+import com.inout.apiserver.base.enums.LanguageType
+
+data class AiAudioCreateObject(
+    val language: LanguageType,
+    val aiVoiceType: AiVoiceType,
+    val content: String,
+    val directory: String,
+)

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/ConversationCreateObject.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/ConversationCreateObject.kt
@@ -2,8 +2,11 @@ package com.inout.apiserver.domain.word
 
 import com.inout.apiserver.base.alias.UserId
 import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.infrastructure.db.word.AiAudio
 
 data class ConversationCreateObject(
     val userId: UserId,
     val wordDefinitionId: WordDefinitionId,
+    val systemMessage: String,
+    val systemAudio: AiAudio,
 )

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/ConversationCreateObject.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/ConversationCreateObject.kt
@@ -1,0 +1,9 @@
+package com.inout.apiserver.domain.word
+
+import com.inout.apiserver.base.alias.UserId
+import com.inout.apiserver.base.alias.WordDefinitionId
+
+data class ConversationCreateObject(
+    val userId: UserId,
+    val wordDefinitionId: WordDefinitionId,
+)

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/SentenceCreateObject.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/SentenceCreateObject.kt
@@ -16,6 +16,7 @@ data class SentenceCreateObject(
         require(content.isNotBlank()) { "content must not be blank" }
         require(translation.isNotBlank()) { "translation must not be blank" }
         require(lexicalCategories.isNotEmpty()) { "lexicalCategories must not be empty" }
+        // TODO: create sometimes fails because of this check, need to enhance ai prompt
         require(content.split(" ").size == lexicalCategories.size) { "content and lexicalCategories size must be equal" }
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/WordAIService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/WordAIService.kt
@@ -1,0 +1,46 @@
+package com.inout.apiserver.domain.word
+
+import com.inout.apiserver.base.enums.AiVoiceType
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.service.openai.OpenAIService
+import com.inout.apiserver.infrastructure.db.word.AiAudio
+import com.inout.apiserver.infrastructure.db.word.AiAudioRepository
+import com.inout.apiserver.infrastructure.s3.S3Service
+import org.springframework.stereotype.Service
+
+@Service
+class WordAIService(
+    private val openAIService: OpenAIService,
+    private val aiAudioRepository: AiAudioRepository,
+    private val s3Service: S3Service,
+) {
+    fun findOrCreateAudio(
+        language: LanguageType,
+        content: String,
+    ): AiAudio {
+        aiAudioRepository
+            .findByLanguageAndContent(language = language, content = content)
+            ?.let { return it }
+
+        val rawAudio = openAIService.fetchSpeechFromText(content)
+        val uploadedDirectory =
+            s3Service.uploadAudio(
+                inputStream = rawAudio.inputStream(),
+                language = language,
+                voiceType = AiVoiceType.ALLOY,
+                tableName = "ai_audios", // TODO: should be dynamic?
+                content = content,
+            )
+
+        return aiAudioRepository.save(
+            AiAudio.fromCreateObject(
+                AiAudioCreateObject(
+                    language = language,
+                    aiVoiceType = AiVoiceType.ALLOY,
+                    content = content,
+                    directory = uploadedDirectory,
+                ),
+            ),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/WordService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/WordService.kt
@@ -12,6 +12,9 @@ import com.inout.apiserver.base.enums.SentenceType
 import com.inout.apiserver.error.BadRequestException
 import com.inout.apiserver.error.ConflictException
 import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.infrastructure.db.word.Conversation
+import com.inout.apiserver.infrastructure.db.word.ConversationRepository
 import com.inout.apiserver.infrastructure.db.word.Sentence
 import com.inout.apiserver.infrastructure.db.word.SentenceFeedback
 import com.inout.apiserver.infrastructure.db.word.SentenceFeedbackRepository
@@ -34,6 +37,7 @@ class WordService(
     private val userSentenceRepository: UserSentenceRepository,
     private val userSentenceFeedbackRepository: UserSentenceFeedbackRepository,
     private val sentenceFeedbackRepository: SentenceFeedbackRepository,
+    private val conversationRepository: ConversationRepository,
 ) {
     fun getWordByNameAndFromLanguageAndToLanguage(
         name: String,
@@ -179,4 +183,14 @@ class WordService(
 
     fun getSentenceFeedbacksByIds(sentenceFeedbackIds: List<SentenceFeedbackId>): List<SentenceFeedback> =
         sentenceFeedbackRepository.findAllByIdIn(sentenceFeedbackIds)
+
+    fun getConversationsBy(
+        user: User,
+        wordDefinitionId: WordDefinitionId,
+    ): List<Conversation> =
+        conversationRepository
+            .findAllByUserIdAndWordDefinitionId(
+                userId = user.id!!,
+                wordDefinitionId = wordDefinitionId,
+            ).sortedBy { it.createdAt }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/WordService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/WordService.kt
@@ -193,4 +193,7 @@ class WordService(
                 userId = user.id!!,
                 wordDefinitionId = wordDefinitionId,
             ).sortedBy { it.createdAt }
+
+    fun createConversation(conversationCreateObject: ConversationCreateObject): Conversation =
+        conversationRepository.save(Conversation.fromCreateObject(conversationCreateObject))
 }

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudio.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudio.kt
@@ -1,0 +1,27 @@
+package com.inout.apiserver.infrastructure.db.word
+
+import com.inout.apiserver.base.alias.AiAudioId
+import com.inout.apiserver.base.enums.AiVoiceType
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.infrastructure.db.TimestampedEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "ai_audios")
+data class AiAudio(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: AiAudioId? = null,
+    @Enumerated(EnumType.STRING)
+    val language: LanguageType,
+    @Enumerated(EnumType.STRING)
+    val voiceType: AiVoiceType,
+    val content: String,
+    val directory: String,
+) : TimestampedEntity()

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudio.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudio.kt
@@ -3,6 +3,7 @@ package com.inout.apiserver.infrastructure.db.word
 import com.inout.apiserver.base.alias.AiAudioId
 import com.inout.apiserver.base.enums.AiVoiceType
 import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.domain.word.AiAudioCreateObject
 import com.inout.apiserver.infrastructure.db.TimestampedEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -24,4 +25,14 @@ data class AiAudio(
     val voiceType: AiVoiceType,
     val content: String,
     val directory: String,
-) : TimestampedEntity()
+) : TimestampedEntity() {
+    companion object {
+        fun fromCreateObject(createObject: AiAudioCreateObject): AiAudio =
+            AiAudio(
+                language = createObject.language,
+                voiceType = createObject.aiVoiceType,
+                content = createObject.content,
+                directory = createObject.directory,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudioRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudioRepository.kt
@@ -1,0 +1,8 @@
+package com.inout.apiserver.infrastructure.db.word
+
+import com.inout.apiserver.base.alias.AiAudioId
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AiAudioRepository : JpaRepository<AiAudio, AiAudioId>

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudioRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/AiAudioRepository.kt
@@ -1,8 +1,15 @@
 package com.inout.apiserver.infrastructure.db.word
 
 import com.inout.apiserver.base.alias.AiAudioId
+import com.inout.apiserver.base.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface AiAudioRepository : JpaRepository<AiAudio, AiAudioId>
+interface AiAudioRepository : JpaRepository<AiAudio, AiAudioId> {
+    // FIXME: potential bug when multiple records are found
+    fun findByLanguageAndContent(
+        language: LanguageType,
+        content: String,
+    ): AiAudio?
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Conversation.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Conversation.kt
@@ -1,0 +1,41 @@
+package com.inout.apiserver.infrastructure.db.word
+
+import com.inout.apiserver.base.alias.ConversationId
+import com.inout.apiserver.base.alias.UserId
+import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.infrastructure.db.TimestampedEntity
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicInsert
+import org.hibernate.annotations.DynamicUpdate
+
+@Entity
+@Table(
+    name = "conversations",
+    indexes = [
+        Index(
+            columnList = "user_id, word_definition_id",
+            name = "idx_conversations_user_id_word_definition_id",
+        ),
+    ],
+)
+@DynamicInsert
+@DynamicUpdate
+data class Conversation(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: ConversationId? = null,
+    val userId: UserId,
+    val wordDefinitionId: WordDefinitionId,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "conversation_id")
+    val messages: MutableList<ConversationMessage> = mutableListOf(),
+) : TimestampedEntity()

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Conversation.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Conversation.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables
 import com.inout.apiserver.base.alias.ConversationId
 import com.inout.apiserver.base.alias.UserId
 import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.base.enums.SenderType
 import com.inout.apiserver.domain.word.ConversationCreateObject
 import com.inout.apiserver.infrastructure.db.TimestampedEntity
 import jakarta.persistence.CascadeType
@@ -46,6 +47,14 @@ data class Conversation(
             Conversation(
                 userId = createObject.userId,
                 wordDefinitionId = createObject.wordDefinitionId,
+                messages =
+                    mutableListOf(
+                        ConversationMessage(
+                            sender = SenderType.SYSTEM,
+                            content = createObject.systemAudio.content,
+                            audio = createObject.systemAudio,
+                        ),
+                    ),
             )
     }
 

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Conversation.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Conversation.kt
@@ -1,8 +1,10 @@
 package com.inout.apiserver.infrastructure.db.word
 
+import com.google.common.collect.Iterables
 import com.inout.apiserver.base.alias.ConversationId
 import com.inout.apiserver.base.alias.UserId
 import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.domain.word.ConversationCreateObject
 import com.inout.apiserver.infrastructure.db.TimestampedEntity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
@@ -38,4 +40,35 @@ data class Conversation(
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "conversation_id")
     val messages: MutableList<ConversationMessage> = mutableListOf(),
-) : TimestampedEntity()
+) : TimestampedEntity() {
+    companion object {
+        fun fromCreateObject(createObject: ConversationCreateObject): Conversation =
+            Conversation(
+                userId = createObject.userId,
+                wordDefinitionId = createObject.wordDefinitionId,
+            )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Conversation
+
+        if (id != other.id) return false
+        if (userId != other.userId) return false
+        if (wordDefinitionId != other.wordDefinitionId) return false
+        if (!Iterables.elementsEqual(messages, other.messages)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + userId.hashCode()
+        result = 31 * result + wordDefinitionId.hashCode()
+        result = 31 * result + messages.toList().hashCode()
+
+        return result
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/ConversationMessage.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/ConversationMessage.kt
@@ -1,0 +1,26 @@
+package com.inout.apiserver.infrastructure.db.word
+
+import com.inout.apiserver.base.alias.ConversationMessageId
+import com.inout.apiserver.base.enums.SenderType
+import com.inout.apiserver.infrastructure.db.TimestampedEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "conversation_messages")
+data class ConversationMessage(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: ConversationMessageId? = null,
+    @Enumerated(EnumType.STRING)
+    val sender: SenderType,
+    val content: String,
+    @ManyToOne(optional = true)
+    val audio: AiAudio? = null,
+) : TimestampedEntity()

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/ConversationRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/ConversationRepository.kt
@@ -1,0 +1,13 @@
+package com.inout.apiserver.infrastructure.db.word
+
+import com.inout.apiserver.base.alias.ConversationId
+import com.inout.apiserver.base.alias.UserId
+import com.inout.apiserver.base.alias.WordDefinitionId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ConversationRepository : JpaRepository<Conversation, ConversationId> {
+    fun findAllByUserIdAndWordDefinitionId(
+        userId: UserId,
+        wordDefinitionId: WordDefinitionId,
+    ): List<Conversation>
+}

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/s3/S3Service.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/s3/S3Service.kt
@@ -5,10 +5,13 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import com.amazonaws.services.s3.model.PutObjectRequest
+import com.inout.apiserver.base.enums.AiVoiceType
+import com.inout.apiserver.base.enums.LanguageType
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import org.springframework.web.multipart.MultipartFile
+import java.io.InputStream
 import java.util.Date
+import java.util.UUID
 
 @Service
 class S3Service(
@@ -21,31 +24,38 @@ class S3Service(
          * audio directory rule:
          * - static/audio/{{language}}/{{rule}}.{{audio speaker}}.mp3
          * - rule?:
-         *   - table name + id + md5 hash of the audio text
-         *   - ex: ai_speeches_1_{{md5 hash of the audio text}}.alloy.mp3
+         *   - table name + UUID
+         *   - ex: ai_speeches_{{uuid}}.alloy.mp3
          */
         private const val AUDIO_PREFIX = "static/audio/"
         private const val PRE_SIGNED_URL_EXPIRATION = 3600 * 1000 // 1 hour
     }
 
-    /**
-     * @param file audio file
-     * @return audio file url
-     */
-    fun saveAudioFile(file: MultipartFile): String {
-        val directory = AUDIO_PREFIX + "english/test.alloy.mp3"
-        amazonS3.putObject(
-            PutObjectRequest(
-                bucket,
-                directory,
-                file.inputStream,
-                null,
-            ).withCannedAcl(CannedAccessControlList.PublicRead),
-        )
+    fun uploadAudio(
+        inputStream: InputStream,
+        language: LanguageType,
+        voiceType: AiVoiceType,
+        tableName: String,
+        content: String,
+    ): String {
+        val directory = getAudioDirectory(language, tableName, content, voiceType)
         /**
          * TODO:
          *  - consider what to do with re-writes
          */
+        amazonS3.putObject(
+            PutObjectRequest(
+                bucket,
+                directory,
+                inputStream,
+                null,
+            ).withCannedAcl(CannedAccessControlList.PublicRead),
+        )
+
+        return directory
+    }
+
+    fun getAudioUrl(directory: String): String {
         val expiration = Date(System.currentTimeMillis() + PRE_SIGNED_URL_EXPIRATION)
         val generatePreSignedUrlRequest =
             GeneratePresignedUrlRequest(bucket, directory)
@@ -53,4 +63,13 @@ class S3Service(
                 .withExpiration(expiration)
         return amazonS3.generatePresignedUrl(generatePreSignedUrlRequest).toString()
     }
+
+    fun getAudioDirectory(
+        language: LanguageType,
+        tableName: String,
+        content: String,
+        voiceType: AiVoiceType,
+    ) = AUDIO_PREFIX +
+        "${language.name.lowercase()}/" +
+        "${tableName}_${UUID.randomUUID()}.${voiceType.name.lowercase()}.mp3"
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/ConversationController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/ConversationController.kt
@@ -1,9 +1,11 @@
 package com.inout.apiserver.interfaces.web.v1
 
 import com.inout.apiserver.application.word.GetConversationsApplication
+import com.inout.apiserver.application.word.StartConversationApplication
 import com.inout.apiserver.config.web.RequestUser
 import com.inout.apiserver.error.HttpException
 import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.interfaces.web.v1.request.StartConversationRequest
 import com.inout.apiserver.interfaces.web.v1.response.ConversationResponse
 import com.inout.apiserver.interfaces.web.v1.response.ResponseListWrapper
 import io.swagger.v3.oas.annotations.Operation
@@ -11,10 +13,13 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.OK
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -23,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/conversations")
 class ConversationController(
     private val getConversationsApplication: GetConversationsApplication,
+    private val startConversationApplication: StartConversationApplication,
 ) {
     @GetMapping
     @Operation(
@@ -73,4 +79,47 @@ class ConversationController(
             OK,
         )
     }
+
+    @PostMapping
+    @Operation(
+        summary = "학습 단어에 대한 대화 시작",
+        description = "학습중인 단어에 대해 대화를 시작합니다. 기존 시작된 사용자가 대화하지 않은 대화가 있으면 해당 대화를 사용합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "대화 시작 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ConversationResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "요청한 단어를 학습중이 아닌 경우 (code: CONVERSATION_1), 이미 선택한 학습 단어로 3개의 대화를 하고있는 경우 (code: CONVERSATION_2)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun startConversation(
+        @RequestBody @Valid request: StartConversationRequest,
+        @Parameter(hidden = true) @RequestUser user: User,
+    ): ResponseEntity<ConversationResponse> =
+        ResponseEntity.ok(
+            ConversationResponse.of(
+                startConversationApplication
+                    .run(
+                        StartConversationApplication.Request(
+                            wordDefinitionId = request.wordDefinitionId,
+                            user = user,
+                        ),
+                    ).conversation,
+            ),
+        )
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/ConversationController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/ConversationController.kt
@@ -1,0 +1,76 @@
+package com.inout.apiserver.interfaces.web.v1
+
+import com.inout.apiserver.application.word.GetConversationsApplication
+import com.inout.apiserver.config.web.RequestUser
+import com.inout.apiserver.error.HttpException
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.interfaces.web.v1.response.ConversationResponse
+import com.inout.apiserver.interfaces.web.v1.response.ResponseListWrapper
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.HttpStatus.OK
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/conversations")
+class ConversationController(
+    private val getConversationsApplication: GetConversationsApplication,
+) {
+    @GetMapping
+    @Operation(
+        summary = "진행중인 대화 목록 조회",
+        description = "학습중인 단어에 대한 대화 목록을 조회합니다.",
+        parameters = [
+            Parameter(
+                name = "wordDefinitionId",
+                description = "단어 정의 ID",
+                required = true,
+                example = "1",
+            ),
+        ],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "대화 목록 조회 성공",
+                useReturnTypeSchema = true,
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "학습중인 단어가 아닌 경우 (code: CONVERSATION_1)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getConversations(
+        @RequestParam(required = true) wordDefinitionId: Long,
+        @Parameter(hidden = true) @RequestUser user: User,
+    ): ResponseEntity<ResponseListWrapper<ConversationResponse>> {
+        val result =
+            getConversationsApplication.run(
+                GetConversationsApplication.Request(
+                    wordDefinitionId = wordDefinitionId,
+                    user = user,
+                ),
+            )
+
+        return ResponseEntity(
+            ResponseListWrapper(
+                data = result.conversations.map { ConversationResponse.of(it) },
+            ),
+            OK,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/request/StartConversationRequest.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/request/StartConversationRequest.kt
@@ -1,0 +1,10 @@
+package com.inout.apiserver.interfaces.web.v1.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+
+data class StartConversationRequest(
+    @field:Min(value = 1L, message = "학습 단어 아이디는 1 이상의 숫자로 입력해주세요.")
+    @Schema(description = "학습 단어 아이디", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val wordDefinitionId: Long,
+)

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationMessageResponse.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationMessageResponse.kt
@@ -1,6 +1,8 @@
 package com.inout.apiserver.interfaces.web.v1.response
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.inout.apiserver.base.enums.SenderType
+import com.inout.apiserver.base.serializer.PreSignedUrlSerializer
 import com.inout.apiserver.infrastructure.db.word.ConversationMessage
 import java.time.Instant
 
@@ -9,6 +11,7 @@ data class ConversationMessageResponse(
     val sender: SenderType,
     val content: String,
     val audioUrl: String?,
+    @JsonSerialize(using = PreSignedUrlSerializer::class)
     val createdAt: Instant? = null,
 ) {
     companion object {

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationMessageResponse.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationMessageResponse.kt
@@ -10,8 +10,8 @@ data class ConversationMessageResponse(
     val id: Long,
     val sender: SenderType,
     val content: String,
-    val audioUrl: String?,
     @JsonSerialize(using = PreSignedUrlSerializer::class)
+    val audioUrl: String?,
     val createdAt: Instant? = null,
 ) {
     companion object {

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationMessageResponse.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationMessageResponse.kt
@@ -1,0 +1,24 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+import com.inout.apiserver.base.enums.SenderType
+import com.inout.apiserver.infrastructure.db.word.ConversationMessage
+import java.time.Instant
+
+data class ConversationMessageResponse(
+    val id: Long,
+    val sender: SenderType,
+    val content: String,
+    val audioUrl: String?,
+    val createdAt: Instant? = null,
+) {
+    companion object {
+        fun of(conversationMessage: ConversationMessage): ConversationMessageResponse =
+            ConversationMessageResponse(
+                id = conversationMessage.id!!,
+                sender = conversationMessage.sender,
+                content = conversationMessage.content,
+                audioUrl = conversationMessage.audio?.directory,
+                createdAt = conversationMessage.createdAt,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationResponse.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ConversationResponse.kt
@@ -1,0 +1,23 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+import com.inout.apiserver.infrastructure.db.word.Conversation
+import java.time.Instant
+
+data class ConversationResponse(
+    val id: Long,
+    val userId: Long,
+    val wordDefinitionId: Long,
+    val messages: List<ConversationMessageResponse>,
+    val createdAt: Instant? = null,
+) {
+    companion object {
+        fun of(conversation: Conversation): ConversationResponse =
+            ConversationResponse(
+                id = conversation.id!!,
+                userId = conversation.userId,
+                wordDefinitionId = conversation.wordDefinitionId,
+                messages = conversation.messages.map { ConversationMessageResponse.of(it) },
+                createdAt = conversation.createdAt,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ResponseListWrapper.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/ResponseListWrapper.kt
@@ -1,0 +1,5 @@
+package com.inout.apiserver.interfaces.web.v1.response
+
+data class ResponseListWrapper<T>(
+    val data: List<T>,
+)

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/GetConversationsApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/GetConversationsApplicationTest.kt
@@ -1,0 +1,109 @@
+package com.inout.apiserver.application.word
+
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.infrastructure.db.word.ConversationRepository
+import com.inout.apiserver.infrastructure.db.word.Word
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.jdbc.core.JdbcTemplate
+
+@InOutSpringBootTest
+class GetConversationsApplicationTest(
+    private val subject: GetConversationsApplication,
+    // repositories
+    private val conversationRepository: ConversationRepository,
+    // factories
+    private val userFactory: UserFactory,
+    private val wordFactory: WordFactory,
+    private val studyFactory: StudyFactory,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        var user: User? = null
+        var word: Word? = null
+
+        beforeEach {
+            user = userFactory.createUser()
+            word = wordFactory.createWord()
+        }
+
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when user is not studying given wordDefinitionId") {
+            var wordDefinitionId = 0L
+
+            beforeEach {
+                wordDefinitionId = word!!.definitions.first().id!!
+                conversationRepository
+                    .findAllByUserIdAndWordDefinitionId(user!!.id!!, wordDefinitionId)
+                    .isEmpty() shouldBe true
+            }
+
+            it("should raise error") {
+                // when
+                val exception =
+                    shouldThrow<BadRequestException> {
+                        subject.run(
+                            GetConversationsApplication.Request(
+                                user = user!!,
+                                wordDefinitionId = wordDefinitionId,
+                            ),
+                        )
+                    }
+
+                // then
+                exception.message shouldBe "User is not studying given wordDefinitionId of $wordDefinitionId"
+                exception.code shouldBe "CONVERSATION_1"
+            }
+        }
+
+        describe("when user is studying given wordDefinitionId") {
+            var wordDefinitionId = 0L
+
+            beforeEach {
+                wordDefinitionId = word!!.definitions.first().id!!
+                studyFactory.createStudy(user!!.id!!, wordDefinitionId)
+            }
+
+            it("should return empty list of conversations when no conversations found") {
+                // when
+                val result =
+                    subject.run(
+                        GetConversationsApplication.Request(
+                            user = user!!,
+                            wordDefinitionId = wordDefinitionId,
+                        ),
+                    )
+
+                // then
+                result.conversations.size shouldBe 0
+            }
+
+            it("should return list of conversations when conversations found") {
+                // given
+                val conversation = wordFactory.createConversation(user!!.id!!, wordDefinitionId)
+
+                // when
+                val result =
+                    subject.run(
+                        GetConversationsApplication.Request(
+                            user = user!!,
+                            wordDefinitionId = wordDefinitionId,
+                        ),
+                    )
+
+                // then
+                result.conversations.size shouldBe 1
+                result.conversations.first().id shouldBe conversation.id
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/StartConversationApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/StartConversationApplicationTest.kt
@@ -5,6 +5,7 @@ import com.inout.apiserver.domain.study.StudyFactory
 import com.inout.apiserver.domain.study.StudyService
 import com.inout.apiserver.domain.user.UserFactory
 import com.inout.apiserver.domain.word.AudioFactory
+import com.inout.apiserver.domain.word.WordAIService
 import com.inout.apiserver.domain.word.WordFactory
 import com.inout.apiserver.error.BadRequestException
 import com.inout.apiserver.extension.cleanUp
@@ -17,6 +18,9 @@ import com.inout.apiserver.infrastructure.db.word.Word
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.data.domain.PageRequest
 import org.springframework.jdbc.core.JdbcTemplate
 
@@ -25,6 +29,8 @@ class StartConversationApplicationTest(
     private val subject: StartConversationApplication,
     // services
     private val studyService: StudyService,
+    @SpyBean
+    private val wordAIService: WordAIService,
     // repositories
     private val conversationRepository: ConversationRepository,
     // factories
@@ -41,6 +47,11 @@ class StartConversationApplicationTest(
         beforeEach {
             user = userFactory.createUser()
             word = wordFactory.createWord()
+
+            // mock calls to wordAIService to save and return a dummy audio
+            doReturn(audioFactory.createAudio())
+                .`when`(wordAIService)
+                .findOrCreateAudio(any(), any())
         }
 
         afterEach {
@@ -174,7 +185,7 @@ class StartConversationApplicationTest(
                         ).size shouldBe 1
                     result.conversation.userId shouldBe user!!.id
                     result.conversation.wordDefinitionId shouldBe wordDefinitionId
-                    result.conversation.messages.isEmpty() shouldBe true
+                    result.conversation.messages.size shouldBe 1
                 }
             }
         }

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/StartConversationApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/StartConversationApplicationTest.kt
@@ -1,0 +1,181 @@
+package com.inout.apiserver.application.word
+
+import com.inout.apiserver.base.enums.SenderType
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.study.StudyService
+import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.AudioFactory
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.infrastructure.db.word.Conversation
+import com.inout.apiserver.infrastructure.db.word.ConversationMessage
+import com.inout.apiserver.infrastructure.db.word.ConversationRepository
+import com.inout.apiserver.infrastructure.db.word.Word
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.data.domain.PageRequest
+import org.springframework.jdbc.core.JdbcTemplate
+
+@InOutSpringBootTest
+class StartConversationApplicationTest(
+    private val subject: StartConversationApplication,
+    // services
+    private val studyService: StudyService,
+    // repositories
+    private val conversationRepository: ConversationRepository,
+    // factories
+    private val audioFactory: AudioFactory,
+    private val userFactory: UserFactory,
+    private val wordFactory: WordFactory,
+    private val studyFactory: StudyFactory,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        var user: User? = null
+        var word: Word? = null
+
+        beforeEach {
+            user = userFactory.createUser()
+            word = wordFactory.createWord()
+        }
+
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when user is not studying given wordDefinitionId") {
+            beforeEach {
+                studyService.getAllByUserId(user!!.id!!, PageRequest.of(0, 10)).totalElements shouldBe 0
+            }
+
+            it("should throw BadRequestException") {
+                // given
+                val wordDefinitionId = word!!.definitions.first().id!!
+
+                // when
+                val result =
+                    shouldThrow<BadRequestException> {
+                        subject.run(
+                            StartConversationApplication.Request(
+                                wordDefinitionId = wordDefinitionId,
+                                user = user!!,
+                            ),
+                        )
+                    }
+
+                // then
+                result.message shouldBe "User is not studying given wordDefinitionId of $wordDefinitionId"
+                result.code shouldBe "CONVERSATION_1"
+            }
+        }
+
+        describe("when user is studying given wordDefinitionId") {
+            var wordDefinitionId = 0L
+
+            beforeEach {
+                wordDefinitionId = word!!.definitions.first().id!!
+                studyFactory.createStudy(userId = user!!.id!!, wordDefinitionId = wordDefinitionId)
+            }
+
+            describe("when user has existing conversation/s") {
+                val conversations = mutableListOf<Conversation>()
+
+                beforeEach {
+                    conversations.add(wordFactory.createConversation(user!!.id!!, wordDefinitionId))
+                    conversations.add(wordFactory.createConversation(user!!.id!!, wordDefinitionId))
+                    conversations.add(wordFactory.createConversation(user!!.id!!, wordDefinitionId))
+                }
+
+                fun populateConversation(conversation: Conversation) {
+                    conversationRepository.save(
+                        conversation.apply {
+                            val audio = audioFactory.createAudio()
+                            messages.add(
+                                ConversationMessage(
+                                    sender = SenderType.SYSTEM,
+                                    content = audio.content,
+                                    audio = audio,
+                                ),
+                            )
+                            messages.add(
+                                ConversationMessage(
+                                    sender = SenderType.USER,
+                                    content = "Hello",
+                                ),
+                            )
+                        },
+                    )
+                }
+
+                it("should return the first conversation with no user messages") {
+                    // when
+                    val firstConversation = conversations.first()
+                    populateConversation(firstConversation)
+                    val result =
+                        subject.run(
+                            StartConversationApplication.Request(
+                                wordDefinitionId = wordDefinitionId,
+                                user = user!!,
+                            ),
+                        )
+
+                    // then
+                    val secondConversation = conversations[1]
+                    result.conversation.id shouldBe secondConversation.id
+                }
+
+                it("should throw BadRequestException when user has reached maximum number of conversations") {
+                    // when
+                    conversations.forEach { populateConversation(it) }
+                    val result =
+                        shouldThrow<BadRequestException> {
+                            subject.run(
+                                StartConversationApplication.Request(
+                                    wordDefinitionId = wordDefinitionId,
+                                    user = user!!,
+                                ),
+                            )
+                        }
+
+                    // then
+                    result.message shouldBe "Reached maximum number of conversations"
+                    result.code shouldBe "CONVERSATION_2"
+                }
+            }
+
+            describe("when new conversation can be started") {
+                beforeEach {
+                    conversationRepository
+                        .findAllByUserIdAndWordDefinitionId(
+                            user!!.id!!,
+                            wordDefinitionId,
+                        ).size shouldBe 0
+                }
+
+                it("should create a new conversation") {
+                    // when
+                    val result =
+                        subject.run(
+                            StartConversationApplication.Request(
+                                wordDefinitionId = wordDefinitionId,
+                                user = user!!,
+                            ),
+                        )
+
+                    // then
+                    conversationRepository
+                        .findAllByUserIdAndWordDefinitionId(
+                            user!!.id!!,
+                            wordDefinitionId,
+                        ).size shouldBe 1
+                    result.conversation.userId shouldBe user!!.id
+                    result.conversation.wordDefinitionId shouldBe wordDefinitionId
+                    result.conversation.messages.isEmpty() shouldBe true
+                }
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/AudioFactory.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/AudioFactory.kt
@@ -1,0 +1,27 @@
+package com.inout.apiserver.domain.word
+
+import com.inout.apiserver.base.enums.AiVoiceType
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.infrastructure.db.word.AiAudio
+import com.inout.apiserver.infrastructure.db.word.AiAudioRepository
+import org.springframework.stereotype.Component
+
+@Component
+class AudioFactory(
+    private val aiAudioRepository: AiAudioRepository,
+) {
+    fun createAudio(
+        language: LanguageType = LanguageType.ENGLISH,
+        aiVoiceType: AiVoiceType = AiVoiceType.ALLOY,
+        content: String = "Let's start a conversation about the word 'book'.",
+        directory: String = "static/audio/english/ai_audios_f7365d23-b387-4b79-844d-a5f9f35b49cf.alloy.mp3",
+    ): AiAudio =
+        aiAudioRepository.save(
+            AiAudio(
+                language = language,
+                voiceType = aiVoiceType,
+                content = content,
+                directory = directory,
+            ),
+        )
+}

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
@@ -9,6 +9,8 @@ import com.inout.apiserver.base.alias.WordId
 import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.base.enums.SentenceType
+import com.inout.apiserver.infrastructure.db.word.Conversation
+import com.inout.apiserver.infrastructure.db.word.ConversationRepository
 import com.inout.apiserver.infrastructure.db.word.Sentence
 import com.inout.apiserver.infrastructure.db.word.SentenceFeedback
 import com.inout.apiserver.infrastructure.db.word.SentenceFeedbackRepository
@@ -29,6 +31,7 @@ class WordFactory(
     private val sentenceFeedbackRepository: SentenceFeedbackRepository,
     private val userSentenceRepository: UserSentenceRepository,
     private val userSentenceFeedbackRepository: UserSentenceFeedbackRepository,
+    private val conversationRepository: ConversationRepository,
 ) {
     companion object {
         @Deprecated("Use member function createWord instead")
@@ -151,6 +154,17 @@ class WordFactory(
             UserSentenceFeedback(
                 userSentenceId = userSentenceId,
                 sentenceFeedbackId = sentenceFeedbackId,
+            ),
+        )
+
+    fun createConversation(
+        userId: UserId,
+        wordDefinitionId: WordDefinitionId,
+    ): Conversation =
+        conversationRepository.save(
+            Conversation(
+                userId = userId,
+                wordDefinitionId = wordDefinitionId,
             ),
         )
 }

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordServiceTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordServiceTest.kt
@@ -3,17 +3,22 @@ package com.inout.apiserver.domain.word
 import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.base.enums.SentenceType
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.user.UserFactory
 import com.inout.apiserver.error.ConflictException
 import com.inout.apiserver.error.NotFoundException
 import com.inout.apiserver.extension.cleanUp
 import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.user.User
+import com.inout.apiserver.infrastructure.db.word.Sentence
 import com.inout.apiserver.infrastructure.db.word.UserSentenceRepository
+import com.inout.apiserver.infrastructure.db.word.Word
 import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import com.inout.apiserver.infrastructure.db.word.WordRepository
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeSortedBy
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.domain.PageRequest
 import org.springframework.jdbc.core.JdbcTemplate
@@ -23,8 +28,13 @@ import java.util.Optional
 class WordServiceTest(
     private val wordRepository: WordRepository,
     private val userSentenceRepository: UserSentenceRepository,
+    // factories
     private val wordFactory: WordFactory,
+    private val userFactory: UserFactory,
+    private val studyFactory: StudyFactory,
+    // services
     private val wordService: WordService,
+    // etc
     private val jdbcTemplate: JdbcTemplate,
 ) : DescribeSpec({
         afterEach {
@@ -211,31 +221,50 @@ class WordServiceTest(
         }
 
         describe("createUserSentence") {
+            var user: User? = null
+            var word: Word?
+            var wordDefinitionId = 0L
+            var sentence: Sentence? = null
+
+            beforeEach {
+                user = userFactory.createUser()
+                word = wordFactory.createWord()
+                wordDefinitionId = word!!.definitions.first().id!!
+                sentence =
+                    wordFactory.createSentence(
+                        wordDefinitionId = wordDefinitionId,
+                    )
+            }
+
             it("should raise ConflictException if userSentence already exists") {
                 // Given
                 val userSentenceCreateObject =
                     UserSentenceCreateObject(
-                        userId = 1L,
-                        wordDefinitionId = 1L,
+                        userId = user!!.id!!,
+                        wordDefinitionId = wordDefinitionId,
                         type = SentenceType.READING,
-                        sentenceId = 1L,
+                        sentenceId = sentence!!.id!!,
                     )
                 wordService.createUserSentence(userSentenceCreateObject)
 
                 // When, Then
-                Assertions.assertThrows(ConflictException::class.java) {
-                    wordService.createUserSentence(userSentenceCreateObject)
-                }
+                val result =
+                    assertThrows<ConflictException> {
+                        wordService.createUserSentence(userSentenceCreateObject)
+                    }
+
+                result.message shouldBe "User Sentence already exists"
+                result.code shouldBe "SENTENCE_2"
             }
 
             it("should save and return UserSentence") {
                 // Given
                 val userSentenceCreateObject =
                     UserSentenceCreateObject(
-                        userId = 1L,
-                        wordDefinitionId = 1L,
+                        userId = user!!.id!!,
+                        wordDefinitionId = wordDefinitionId,
                         type = SentenceType.READING,
-                        sentenceId = 1L,
+                        sentenceId = sentence!!.id!!,
                     )
 
                 // When
@@ -250,6 +279,35 @@ class WordServiceTest(
                     userId = userSentenceCreateObject.userId,
                     sentenceId = userSentenceCreateObject.sentenceId,
                 ) shouldBe result
+            }
+        }
+
+        describe("getConversationsBy") {
+            var user: User? = null
+            var word: Word?
+            var wordDefinitionId = 0L
+
+            beforeEach {
+                user = userFactory.createUser()
+                word = wordFactory.createWord()
+                wordDefinitionId = word!!.definitions.first().id!!
+                studyFactory.createStudy(user!!.id!!, wordDefinitionId)
+            }
+
+            it("should return empty list if no conversations found") {
+                wordService.getConversationsBy(user!!, wordDefinitionId) shouldBe emptyList()
+            }
+
+            it("should return list of conversations sorted by createdAt") {
+                val conversations =
+                    (1..3)
+                        .map {
+                            wordFactory.createConversation(user!!.id!!, wordDefinitionId)
+                        }
+
+                val result = wordService.getConversationsBy(user!!, wordDefinitionId)
+                result shouldBe conversations
+                result shouldBeSortedBy { it.createdAt!! }
             }
         }
     })


### PR DESCRIPTION
- add conversation, conversation message, and ai audio
  - conversation has multiple conversation messages
  - conversation message with sender of SYSTEM has audio, while send of USER does not
- add ResponseListWrapper which holds list of requested data
  - designed to ignore paging for small number of list
- add JacksonConfig and PreSignedUrlSerializer to translate audio's directory into url
- add getting & starting conversation flow
- change audio's directory strategy to using UUID
- add WordAIService
  - responsible for creating and uploading audio
  - why create a separate service? needed to merge two 3rd party calls and stream it down to internal db

https://inoutedu.atlassian.net/browse/IO-40