### PR TITLE
feature: [Word] Add wordId field on WordDefinition

### DIFF
--- a/app/src/main/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplication.kt
@@ -74,7 +74,7 @@ class ReadOrCreateDailyStudySetApplication(
                                                             code = "STUDY_2",
                                                         )
                                                     }
-                                                },
+                                                }.toMutableList(),
                                     )
                                 }
                                 ?: throw NotFoundException(message = "Data Integrity Error", code = "STUDY_2"),

--- a/app/src/main/kotlin/com/inout/apiserver/domain/word/WordService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/word/WordService.kt
@@ -25,6 +25,7 @@ import com.inout.apiserver.infrastructure.db.word.UserSentenceFeedback
 import com.inout.apiserver.infrastructure.db.word.UserSentenceFeedbackRepository
 import com.inout.apiserver.infrastructure.db.word.UserSentenceRepository
 import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import com.inout.apiserver.infrastructure.db.word.WordRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -58,7 +59,9 @@ class WordService(
             throw ConflictException(message = "Word already exists", code = "WORD_1")
         }
 
-        return wordRepository.save(Word.fromCreateObject(wordCreateObject))
+        val newWord = wordRepository.save(Word.fromCreateObject(wordCreateObject))
+        val definitions = wordCreateObject.definitions.map { WordDefinition.fromCreateObject(it, newWord) }
+        return wordRepository.save(newWord.addDefinitions(definitions))
     }
 
     @Transactional
@@ -76,14 +79,16 @@ class WordService(
     fun getWordByWordDefinitionId(wordDefinitionId: WordDefinitionId): Word =
         wordRepository
             .findByWordDefinitionId(wordDefinitionId)
-            ?.let { word -> word.copy(definitions = word.definitions.filter { it.id == wordDefinitionId }) }
+            ?.let { word ->
+                word.copy(definitions = word.definitions.filter { it.id == wordDefinitionId }.toMutableList())
+            }
             ?: throw NotFoundException(message = "Word Definition not found", code = "WORD_2")
 
     fun getWordsByWordDefinitionIds(wordDefinitionIds: List<WordDefinitionId>): List<Word> {
         val ids = wordDefinitionIds.toSet()
         return wordRepository
             .findAllByWordDefinitionIds(wordDefinitionIds)
-            .map { word -> word.copy(definitions = word.definitions.filter { it.id in ids }) }
+            .map { word -> word.copy(definitions = word.definitions.filter { it.id in ids }.toMutableList()) }
     }
 
     fun getSentencesByWordDefinitionId(wordDefinitionId: WordDefinitionId): List<Sentence> =

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
@@ -13,7 +13,6 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -38,9 +37,8 @@ data class Word(
     val fromLanguage: LanguageType,
     @Enumerated(EnumType.STRING)
     val toLanguage: LanguageType,
-    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
-    @JoinColumn(name = "word_id")
-    val definitions: List<WordDefinition>,
+    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, mappedBy = "word", orphanRemoval = true)
+    val definitions: MutableList<WordDefinition> = mutableListOf(),
 ) : TimestampedEntity() {
     companion object {
         fun fromCreateObject(createObject: WordCreateObject): Word =
@@ -48,8 +46,13 @@ data class Word(
                 name = createObject.name,
                 fromLanguage = createObject.fromLanguage,
                 toLanguage = createObject.toLanguage,
-                definitions = createObject.definitions.map { WordDefinition.fromCreateObject(it) },
             )
+    }
+
+    fun addDefinitions(definitions: List<WordDefinition>): Word {
+        this.definitions.addAll(definitions)
+
+        return this
     }
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -37,7 +38,8 @@ data class Word(
     val fromLanguage: LanguageType,
     @Enumerated(EnumType.STRING)
     val toLanguage: LanguageType,
-    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, mappedBy = "word", orphanRemoval = true)
+    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
+    @JoinColumn(name = "word_id")
     val definitions: MutableList<WordDefinition> = mutableListOf(),
 ) : TimestampedEntity() {
     companion object {

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordDefinition.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordDefinition.kt
@@ -1,17 +1,17 @@
 package com.inout.apiserver.infrastructure.db.word
 
 import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.base.alias.WordId
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.domain.word.WordDefinitionCreateObject
 import com.inout.apiserver.infrastructure.db.TimestampedEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -20,9 +20,8 @@ data class WordDefinition(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: WordDefinitionId? = null,
-    @ManyToOne
-    @JoinColumn(name = "word_id")
-    val word: Word,
+    @Column(nullable = false, name = "word_id")
+    val wordId: WordId,
     @Enumerated(EnumType.STRING)
     val lexicalCategory: LexicalCategoryType,
     val meaning: String,
@@ -34,37 +33,10 @@ data class WordDefinition(
             word: Word,
         ): WordDefinition =
             WordDefinition(
-                word = word,
+                wordId = word.id!!,
                 lexicalCategory = createObject.lexicalCategory,
                 meaning = createObject.meaning,
                 preContext = createObject.preContext,
             )
-    }
-
-    override fun toString(): String =
-        "WordDefinition(id=$id, wordId=${word.id}, lexicalCategory=$lexicalCategory, meaning='$meaning', preContext='$preContext')"
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as WordDefinition
-
-        if (id != other.id) return false
-        if (word.id != other.word.id) return false
-        if (lexicalCategory != other.lexicalCategory) return false
-        if (meaning != other.meaning) return false
-        if (preContext != other.preContext) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = id?.hashCode() ?: 0
-        result = 31 * result + word.hashCode()
-        result = 31 * result + lexicalCategory.hashCode()
-        result = 31 * result + meaning.hashCode()
-        result = 31 * result + preContext.hashCode()
-        return result
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordDefinition.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordDefinition.kt
@@ -10,6 +10,8 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -18,17 +20,51 @@ data class WordDefinition(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: WordDefinitionId? = null,
+    @ManyToOne
+    @JoinColumn(name = "word_id")
+    val word: Word,
     @Enumerated(EnumType.STRING)
     val lexicalCategory: LexicalCategoryType,
     val meaning: String,
     val preContext: String,
 ) : TimestampedEntity() {
     companion object {
-        fun fromCreateObject(createObject: WordDefinitionCreateObject): WordDefinition =
+        fun fromCreateObject(
+            createObject: WordDefinitionCreateObject,
+            word: Word,
+        ): WordDefinition =
             WordDefinition(
+                word = word,
                 lexicalCategory = createObject.lexicalCategory,
                 meaning = createObject.meaning,
                 preContext = createObject.preContext,
             )
+    }
+
+    override fun toString(): String =
+        "WordDefinition(id=$id, wordId=${word.id}, lexicalCategory=$lexicalCategory, meaning='$meaning', preContext='$preContext')"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as WordDefinition
+
+        if (id != other.id) return false
+        if (word.id != other.word.id) return false
+        if (lexicalCategory != other.lexicalCategory) return false
+        if (meaning != other.meaning) return false
+        if (preContext != other.preContext) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + word.hashCode()
+        result = 31 * result + lexicalCategory.hashCode()
+        result = 31 * result + meaning.hashCode()
+        result = 31 * result + preContext.hashCode()
+        return result
     }
 }

--- a/app/src/test/kotlin/com/inout/apiserver/application/study/CreateStudyApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/study/CreateStudyApplicationTest.kt
@@ -1,161 +1,109 @@
 package com.inout.apiserver.application.study
 
-import com.inout.apiserver.base.alias.UserId
-import com.inout.apiserver.base.enums.FsrsCardState
-import com.inout.apiserver.base.enums.LanguageType
-import com.inout.apiserver.base.enums.LexicalCategoryType
-import com.inout.apiserver.domain.study.StudyService
-import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordFactory
 import com.inout.apiserver.error.ConflictException
 import com.inout.apiserver.error.NotFoundException
-import com.inout.apiserver.infrastructure.db.study.Study
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
 import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
-import com.inout.apiserver.infrastructure.db.word.WordDefinition
-import com.inout.fsrs.model.Card
-import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Test
-import java.time.Instant
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.Optional
 
-class CreateStudyApplicationTest {
-    private val studyService = mockk<StudyService>()
-    private val wordService = mockk<WordService>()
-    private val createStudyApplication = CreateStudyApplication(studyService, wordService)
-    private val now = Instant.now()
+@InOutSpringBootTest
+class CreateStudyApplicationTest(
+    private val subject: CreateStudyApplication,
+    // factories
+    private val userFactory: UserFactory,
+    private val wordFactory: WordFactory,
+    private val studyFactory: StudyFactory,
+    // repositories
+    private val wordRepository: WordRepository,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        var user: User? = null
 
-    private fun createWords(count: Int): List<Word> =
-        (1..count).map { i ->
-            Word(
-                id = i.toLong(),
-                name = "name$i",
-                fromLanguage = LanguageType.ENGLISH,
-                toLanguage = LanguageType.KOREAN,
-                definitions =
-                    listOf(
-                        WordDefinition(
-                            id = i.toLong(),
-                            lexicalCategory = LexicalCategoryType.NOUN,
-                            meaning = "meaning$i",
-                            preContext = "preContext$i",
+        beforeEach {
+            user = userFactory.createUser()
+        }
+
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when word definition does not exists") {
+            it("should raise error") {
+                // given
+                val wordDefinitionId = 1L
+                wordRepository.findById(wordDefinitionId) shouldBe Optional.empty()
+
+                // when
+                val result =
+                    shouldThrow<NotFoundException> {
+                        subject.run(
+                            CreateStudyApplication.Request(
+                                user = user!!,
+                                wordDefinitionId = wordDefinitionId,
+                            ),
+                        )
+                    }
+
+                // then
+                result.message shouldBe "Word Definition not found"
+                result.code shouldBe "WORD_2"
+            }
+        }
+
+        describe("when word definition exists") {
+            var word: Word? = null
+            var wordDefinitionId = 0L
+
+            beforeEach {
+                word = wordFactory.createWord()
+                wordDefinitionId = word!!.definitions.first().id!!
+            }
+
+            it("should raise error when user is already studying the word definition") {
+                // given
+                studyFactory.createStudy(userId = user!!.id!!, wordDefinitionId = wordDefinitionId)
+
+                // when
+                val result =
+                    shouldThrow<ConflictException> {
+                        subject.run(
+                            CreateStudyApplication.Request(
+                                user = user!!,
+                                wordDefinitionId = wordDefinitionId,
+                            ),
+                        )
+                    }
+
+                // then
+                result.message shouldBe "Study already exists"
+                result.code shouldBe "STUDY_1"
+            }
+
+            it("should return StudyWord of the created study") {
+                // when
+                val result =
+                    subject.run(
+                        CreateStudyApplication.Request(
+                            user = user!!,
+                            wordDefinitionId = wordDefinitionId,
                         ),
-                    ),
-            )
+                    )
+
+                // then
+                result.study.userId shouldBe user!!.id!!
+                result.study.wordDefinitionId shouldBe wordDefinitionId
+                result.word shouldBe word!!
+            }
         }
-
-    private fun createStudy(
-        word: Word,
-        userId: UserId,
-    ): Study {
-        val fsrsCard = Card.createEmptyCard()
-        return Study(
-            id = 1L,
-            userId = userId,
-            wordDefinitionId = word.definitions.first().id!!,
-            state = FsrsCardState.of(fsrsCard.state),
-            due = fsrsCard.due,
-            stability = fsrsCard.stability,
-            difficulty = fsrsCard.difficulty,
-            elapsedDays = fsrsCard.elapsedDays,
-            scheduledDays = fsrsCard.scheduledDays,
-            reps = fsrsCard.reps,
-            lapses = fsrsCard.lapses,
-            lastReview = fsrsCard.lastReview,
-            reviewLogs = emptyList(),
-        ).apply {
-            createdAt = now
-            updatedAt = now
-        }
-    }
-
-    @Test
-    fun `run - should raise error when word definition does not exist`() {
-        // Given
-        val user =
-            mockk<User> {
-                every { id } returns 1L
-            }
-        val wordDefinitionId = 1L
-        every { wordService.getWordByWordDefinitionId(wordDefinitionId) } throws
-            NotFoundException(
-                message = "Word Definition not found",
-                code = "WORD_2",
-            )
-
-        // When
-        val sut =
-            assertThrows(NotFoundException::class.java) {
-                createStudyApplication.run(
-                    CreateStudyApplication.Request(
-                        user = user,
-                        wordDefinitionId = wordDefinitionId,
-                    ),
-                )
-            }
-
-        // Then
-        assertEquals("Word Definition not found", sut.message)
-        assertEquals("WORD_2", sut.code)
-    }
-
-    @Test
-    fun `run - should raise error when study creation fails`() {
-        // Given
-        val wordDefinitionId = 1L
-        val word = createWords(1).first()
-        val user =
-            mockk<User> {
-                every { id } returns 1L
-            }
-        every { wordService.getWordByWordDefinitionId(wordDefinitionId) } returns word
-        every { studyService.createStudy(any(), any()) } throws
-            ConflictException(
-                message = "Study already exists",
-                code = "STUDY_1",
-            )
-
-        // When
-        val sut =
-            assertThrows(ConflictException::class.java) {
-                createStudyApplication.run(
-                    CreateStudyApplication.Request(
-                        user = user,
-                        wordDefinitionId = wordDefinitionId,
-                    ),
-                )
-            }
-
-        // Then
-        assertEquals("Study already exists", sut.message)
-        assertEquals("STUDY_1", sut.code)
-    }
-
-    @Test
-    fun `run - should return created study word`() {
-        // Given
-        val wordDefinitionId = 1L
-        val word = createWords(1).first()
-        val user =
-            mockk<User> {
-                every { id } returns 1L
-            }
-        val study = createStudy(word, user.id!!)
-        every { wordService.getWordByWordDefinitionId(wordDefinitionId) } returns word
-        every { studyService.createStudy(any(), any()) } returns study
-
-        // When
-        val sut =
-            createStudyApplication.run(
-                CreateStudyApplication.Request(
-                    user = user,
-                    wordDefinitionId = wordDefinitionId,
-                ),
-            )
-
-        // Then
-        assertEquals(study, sut.study)
-        assertEquals(word, sut.word)
-    }
-}
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/study/ReadOrCreateDailyStudySetApplicationTest.kt
@@ -4,6 +4,7 @@ import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.domain.study.StudyFactory
 import com.inout.apiserver.domain.study.StudyService
 import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordDefinitionCreateObject
 import com.inout.apiserver.domain.word.WordFactory
 import com.inout.apiserver.error.BadRequestException
 import com.inout.apiserver.error.NotFoundException
@@ -11,7 +12,6 @@ import com.inout.apiserver.extension.cleanUp
 import com.inout.apiserver.helper.InOutSpringBootTest
 import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
-import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -41,12 +41,12 @@ class ReadOrCreateDailyStudySetApplicationTest(
                 wordFactory.createWord(
                     wordDefinitions =
                         listOf(
-                            WordDefinition(
+                            WordDefinitionCreateObject(
                                 lexicalCategory = LexicalCategoryType.NOUN,
                                 meaning = "책",
                                 preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                             ),
-                            WordDefinition(
+                            WordDefinitionCreateObject(
                                 lexicalCategory = LexicalCategoryType.VERB,
                                 meaning = "예약하다",
                                 preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",

--- a/app/src/test/kotlin/com/inout/apiserver/application/study/ReadStudiesApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/study/ReadStudiesApplicationTest.kt
@@ -1,127 +1,123 @@
 package com.inout.apiserver.application.study
 
-import com.inout.apiserver.base.alias.UserId
-import com.inout.apiserver.base.enums.FsrsCardState
-import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
-import com.inout.apiserver.domain.study.StudyService
-import com.inout.apiserver.domain.word.WordService
-import com.inout.apiserver.error.InternalServerErrorException
-import com.inout.apiserver.infrastructure.db.study.Study
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordDefinitionCreateObject
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
-import com.inout.apiserver.infrastructure.db.word.WordDefinition
-import com.inout.fsrs.model.Card
-import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.data.domain.PageRequest
+import org.springframework.jdbc.core.JdbcTemplate
 
-class ReadStudiesApplicationTest {
-    private val studyService = mockk<StudyService>()
-    private val wordService = mockk<WordService>()
-    private val readStudiesApplication = ReadStudiesApplication(studyService, wordService)
-
-    private fun createWords(count: Int): List<Word> =
-        (1..count).map { i ->
-            Word(
-                id = i.toLong(),
-                name = "name$i",
-                fromLanguage = LanguageType.ENGLISH,
-                toLanguage = LanguageType.KOREAN,
-                definitions =
-                    listOf(
-                        WordDefinition(
-                            id = i.toLong(),
-                            lexicalCategory = LexicalCategoryType.NOUN,
-                            meaning = "meaning$i",
-                            preContext = "preContext$i",
-                        ),
-                    ),
-            )
+@InOutSpringBootTest
+class ReadStudiesApplicationTest(
+    private val subject: ReadStudiesApplication,
+    // factories
+    private val userFactory: UserFactory,
+    private val wordFactory: WordFactory,
+    private val studyFactory: StudyFactory,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        afterEach {
+            jdbcTemplate.cleanUp()
         }
 
-    private fun createStudies(
-        count: Int,
-        userId: UserId,
-    ): List<Study> {
-        val fsrsCard = Card.createEmptyCard()
-        return (1..count).map { i ->
-            Study(
-                id = i.toLong(),
-                userId = userId,
-                wordDefinitionId = i.toLong(),
-                state = FsrsCardState.of(fsrsCard.state),
-                due = fsrsCard.due,
-                stability = fsrsCard.stability,
-                difficulty = fsrsCard.difficulty,
-                elapsedDays = fsrsCard.elapsedDays,
-                scheduledDays = fsrsCard.scheduledDays,
-                reps = fsrsCard.reps,
-                lapses = fsrsCard.lapses,
-                lastReview = fsrsCard.lastReview,
-                reviewLogs = emptyList(),
-            )
-        }
-    }
+        describe("run") {
+            var user: User? = null
+            var words: MutableList<Word>? = null
 
-    @Test
-    fun `run - should raise error when study with no word exists`() {
-        // Given
-        val userId = 1L
-        val pageable = mockk<Pageable>()
-        val words = createWords(1)
-        val studies = createStudies(2, userId)
-        val wordDefinitionIds = studies.map { it.wordDefinitionId }
-
-        every { studyService.getAllByUserId(userId, pageable) } returns PageImpl(studies)
-        every { wordService.getWordsByWordDefinitionIds(wordDefinitionIds) } returns words
-
-        // When
-        val sut =
-            assertThrows(InternalServerErrorException::class.java) {
-                readStudiesApplication.run(
-                    ReadStudiesApplication.Request(
-                        userId = userId,
-                        pageable = pageable,
-                    ),
-                )
+            beforeEach {
+                user = userFactory.createUser()
+                words = mutableListOf()
+                val word1 =
+                    wordFactory.createWord(
+                        name = "board",
+                        wordDefinitions =
+                            listOf(
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.NOUN,
+                                    meaning = "판자",
+                                    preContext = "무엇을 올리거나 붙이기 위해 사용되는 넓고 평평한 나무 조각",
+                                ),
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.VERB,
+                                    meaning = "탑승하다",
+                                    preContext = "특정한 교통 수단에 몸을 올리다",
+                                ),
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.ADJECTIVE,
+                                    meaning = "공공의",
+                                    preContext = "공공의 기관이나 단체에 속한",
+                                ),
+                            ),
+                    )
+                words!!.add(word1)
+                val word2 =
+                    wordFactory.createWord(
+                        name = "boast",
+                        wordDefinitions =
+                            listOf(
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.VERB,
+                                    meaning = "자랑하다",
+                                    preContext = "자신의 능력이나 성과를 자랑스럽게 말하다",
+                                ),
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.NOUN,
+                                    meaning = "자랑",
+                                    preContext = "자신의 능력이나 성과를 자랑스럽게 말함",
+                                ),
+                            ),
+                    )
+                words!!.add(word2)
+                val word3 =
+                    wordFactory.createWord(
+                        name = "book",
+                        wordDefinitions =
+                            listOf(
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.NOUN,
+                                    meaning = "책",
+                                    preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+                                ),
+                                WordDefinitionCreateObject(
+                                    lexicalCategory = LexicalCategoryType.VERB,
+                                    meaning = "예약하다",
+                                    preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                                ),
+                            ),
+                    )
+                words!!.add(word3)
             }
 
-        // Then
-        assertEquals("Data Integrity Error", sut.message)
-        assertEquals("STUDY_2", sut.code)
-    }
+            it("should return studies") {
+                // given
+                val targetWordDefinitionIds = words!!.map { it.definitions.first().id!! }
+                val studies =
+                    targetWordDefinitionIds.map { studyFactory.createStudy(userId = user!!.id!!, wordDefinitionId = it) }
+                val pageable = PageRequest.of(0, studies.size - 1)
 
-    @Test
-    fun `run - should return studies`() {
-        // Given
-        val userId = 1L
-        val pageable = mockk<Pageable>()
-        val words = createWords(2)
-        val studies = createStudies(2, userId)
-        val wordDefinitionIds = studies.map { it.wordDefinitionId }
+                // when
+                val result = subject.run(ReadStudiesApplication.Request(userId = user!!.id!!, pageable = pageable))
 
-        every { studyService.getAllByUserId(userId, pageable) } returns PageImpl(studies)
-        every { wordService.getWordsByWordDefinitionIds(wordDefinitionIds) } returns words
-
-        // When
-        val sut =
-            readStudiesApplication.run(
-                ReadStudiesApplication.Request(
-                    userId = userId,
-                    pageable = pageable,
-                ),
-            )
-
-        // Then
-        assertEquals(2, sut.totalCount)
-        assertEquals(2, sut.studies.size)
-        assertEquals(studies[0], sut.studies[0].study)
-        assertEquals(words[0], sut.studies[0].word)
-        assertEquals(studies[1], sut.studies[1].study)
-        assertEquals(words[1], sut.studies[1].word)
-    }
-}
+                // then
+                result.totalCount shouldBe studies.size.toLong()
+                result.studies.size shouldBe studies.size - 1
+                result.studies.forEachIndexed { index, studyWord ->
+                    studyWord.study shouldBe studies[index]
+                    studyWord.word.id shouldBe words!![index].id
+                    studyWord.word.name shouldBe words!![index].name
+                    studyWord.word.definitions.size shouldBe 1
+                    studyWord.word.definitions
+                        .first()
+                        .id shouldBe studyWord.study.wordDefinitionId
+                }
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/ReadWordsApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/ReadWordsApplicationTest.kt
@@ -4,12 +4,12 @@ import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.domain.study.StudyFactory
 import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordDefinitionCreateObject
 import com.inout.apiserver.domain.word.WordFactory
 import com.inout.apiserver.extension.cleanUp
 import com.inout.apiserver.helper.InOutSpringBootTest
 import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
-import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
@@ -71,17 +71,17 @@ class ReadWordsApplicationTest(
                         name = "board",
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "판자",
                                     preContext = "무엇을 올리거나 붙이기 위해 사용되는 넓고 평평한 나무 조각",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "탑승하다",
                                     preContext = "특정한 교통 수단에 몸을 올리다",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.ADJECTIVE,
                                     meaning = "공공의",
                                     preContext = "공공의 기관이나 단체에 속한",
@@ -94,12 +94,12 @@ class ReadWordsApplicationTest(
                         name = "boast",
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "자랑하다",
                                     preContext = "자신의 능력이나 성과를 자랑스럽게 말하다",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "자랑",
                                     preContext = "자신의 능력이나 성과를 자랑스럽게 말함",
@@ -112,12 +112,12 @@ class ReadWordsApplicationTest(
                         name = "book",
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "책",
                                     preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "예약하다",
                                     preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",

--- a/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyServiceTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyServiceTest.kt
@@ -4,6 +4,7 @@ import com.inout.apiserver.base.enums.FsrsCardRating
 import com.inout.apiserver.base.enums.FsrsCardState
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordDefinitionCreateObject
 import com.inout.apiserver.domain.word.WordFactory
 import com.inout.apiserver.error.BadRequestException
 import com.inout.apiserver.error.ConflictException
@@ -13,7 +14,6 @@ import com.inout.apiserver.infrastructure.db.study.DailyStudySetRepository
 import com.inout.apiserver.infrastructure.db.study.Study
 import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
-import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import com.inout.fsrs.base.plusDays
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
@@ -75,12 +75,12 @@ class StudyServiceTest(
                     wordFactory.createWord(
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "책",
                                     preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "예약하다",
                                     preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
@@ -214,12 +214,12 @@ class StudyServiceTest(
                     wordFactory.createWord(
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "책",
                                     preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "예약하다",
                                     preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
@@ -255,12 +255,12 @@ class StudyServiceTest(
                     wordFactory.createWord(
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "책",
                                     preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "예약하다",
                                     preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
@@ -351,12 +351,12 @@ class StudyServiceTest(
                     wordFactory.createWord(
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "책",
                                     preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                                 ),
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.VERB,
                                     meaning = "예약하다",
                                     preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
@@ -410,7 +410,7 @@ class StudyServiceTest(
                         name = "booked",
                         wordDefinitions =
                             listOf(
-                                WordDefinition(
+                                WordDefinitionCreateObject(
                                     lexicalCategory = LexicalCategoryType.NOUN,
                                     meaning = "예약된",
                                     preContext = "미리 자리를 확보한",
@@ -444,7 +444,7 @@ class StudyServiceTest(
                                 name = "booked",
                                 wordDefinitions =
                                     listOf(
-                                        WordDefinition(
+                                        WordDefinitionCreateObject(
                                             lexicalCategory = LexicalCategoryType.NOUN,
                                             meaning = "예약된",
                                             preContext = "미리 자리를 확보한",
@@ -461,7 +461,7 @@ class StudyServiceTest(
                                 name = "bank",
                                 wordDefinitions =
                                     listOf(
-                                        WordDefinition(
+                                        WordDefinitionCreateObject(
                                             lexicalCategory = LexicalCategoryType.NOUN,
                                             meaning = "은행",
                                             preContext = "돈을 보관하거나 대출을 해주는 기관",
@@ -502,7 +502,7 @@ class StudyServiceTest(
                             name = "booked",
                             wordDefinitions =
                                 listOf(
-                                    WordDefinition(
+                                    WordDefinitionCreateObject(
                                         lexicalCategory = LexicalCategoryType.NOUN,
                                         meaning = "예약된",
                                         preContext = "미리 자리를 확보한",
@@ -521,7 +521,7 @@ class StudyServiceTest(
                             name = "bank",
                             wordDefinitions =
                                 listOf(
-                                    WordDefinition(
+                                    WordDefinitionCreateObject(
                                         lexicalCategory = LexicalCategoryType.NOUN,
                                         meaning = "은행",
                                         preContext = "돈을 보관하거나 대출을 해주는 기관",

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
@@ -36,26 +36,26 @@ class WordFactory(
         name: String = "book",
         fromLanguage: LanguageType = LanguageType.ENGLISH,
         toLanguage: LanguageType = LanguageType.KOREAN,
-        wordDefinitions: List<WordDefinition> =
+        wordDefinitions: List<WordDefinitionCreateObject> =
             listOf(
-                WordDefinition(
+                WordDefinitionCreateObject(
                     lexicalCategory = LexicalCategoryType.NOUN,
                     meaning = "책",
                     preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                 ),
             ),
-    ): Word =
-        wordRepository
-            .save(
+    ): Word {
+        val word =
+            wordRepository.save(
                 Word(
                     name = name,
                     fromLanguage = fromLanguage,
                     toLanguage = toLanguage,
-                    definitions = wordDefinitions,
                 ),
-            ).let {
-                wordRepository.findById(it.id!!).get()
-            }
+            )
+        word.addDefinitions(wordDefinitions.map { WordDefinition.fromCreateObject(it, word) })
+        return wordRepository.save(word).let { wordRepository.findById(it.id!!).get() }
+    }
 
     fun createSentence(
         wordDefinitionId: WordDefinitionId,

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordServiceTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordServiceTest.kt
@@ -130,10 +130,12 @@ class WordServiceTest(
                 res.toLanguage shouldBe wordCreateObject.toLanguage
                 res.definitions.forEachIndexed { index, wordDefinition ->
                     wordDefinition.id shouldNotBe null
-                    wordDefinition.word shouldBe res
+                    wordDefinition.wordId shouldBe res.id
                     wordDefinition.lexicalCategory shouldBe wordCreateObject.definitions[index].lexicalCategory
                     wordDefinition.meaning shouldBe wordCreateObject.definitions[index].meaning
                     wordDefinition.preContext shouldBe wordCreateObject.definitions[index].preContext
+                    wordDefinition.createdAt shouldNotBe null
+                    wordDefinition.updatedAt shouldNotBe null
                 }
                 res.createdAt shouldNotBe null
                 res.updatedAt shouldNotBe null

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordServiceTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordServiceTest.kt
@@ -13,7 +13,6 @@ import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Sentence
 import com.inout.apiserver.infrastructure.db.word.UserSentenceRepository
 import com.inout.apiserver.infrastructure.db.word.Word
-import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import com.inout.apiserver.infrastructure.db.word.WordRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeSortedBy
@@ -106,10 +105,21 @@ class WordServiceTest(
             it("should return created Word") {
                 val wordCreateObject =
                     WordCreateObject(
-                        name = "name",
+                        name = "book",
                         fromLanguage = LanguageType.ENGLISH,
                         toLanguage = LanguageType.KOREAN,
-                        definitions = emptyList(),
+                        listOf(
+                            WordDefinitionCreateObject(
+                                lexicalCategory = LexicalCategoryType.NOUN,
+                                meaning = "책",
+                                preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+                            ),
+                            WordDefinitionCreateObject(
+                                lexicalCategory = LexicalCategoryType.VERB,
+                                meaning = "예약하다",
+                                preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                            ),
+                        ),
                     )
 
                 val res = wordService.createWord(wordCreateObject)
@@ -118,7 +128,13 @@ class WordServiceTest(
                 res.name shouldBe wordCreateObject.name
                 res.fromLanguage shouldBe wordCreateObject.fromLanguage
                 res.toLanguage shouldBe wordCreateObject.toLanguage
-                res.definitions shouldBe wordCreateObject.definitions
+                res.definitions.forEachIndexed { index, wordDefinition ->
+                    wordDefinition.id shouldNotBe null
+                    wordDefinition.word shouldBe res
+                    wordDefinition.lexicalCategory shouldBe wordCreateObject.definitions[index].lexicalCategory
+                    wordDefinition.meaning shouldBe wordCreateObject.definitions[index].meaning
+                    wordDefinition.preContext shouldBe wordCreateObject.definitions[index].preContext
+                }
                 res.createdAt shouldNotBe null
                 res.updatedAt shouldNotBe null
                 wordRepository.findById(res.id!!) shouldBe Optional.of(res)
@@ -157,7 +173,13 @@ class WordServiceTest(
 
                 val res = wordService.getWordByWordDefinitionId(wordDefinitionId)
 
-                res shouldBe word.copy(definitions = word.definitions.filter { it.id == wordDefinitionId })
+                res shouldBe
+                    word.copy(
+                        definitions =
+                            word.definitions
+                                .filter { it.id == wordDefinitionId }
+                                .toMutableList(),
+                    )
             }
         }
 
@@ -171,12 +193,12 @@ class WordServiceTest(
                             toLanguage = LanguageType.KOREAN,
                             wordDefinitions =
                                 listOf(
-                                    WordDefinition(
+                                    WordDefinitionCreateObject(
                                         lexicalCategory = LexicalCategoryType.NOUN,
                                         meaning = "책",
                                         preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                                     ),
-                                    WordDefinition(
+                                    WordDefinitionCreateObject(
                                         lexicalCategory = LexicalCategoryType.VERB,
                                         meaning = "예약하다",
                                         preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
@@ -189,12 +211,12 @@ class WordServiceTest(
                             toLanguage = LanguageType.KOREAN,
                             wordDefinitions =
                                 listOf(
-                                    WordDefinition(
+                                    WordDefinitionCreateObject(
                                         lexicalCategory = LexicalCategoryType.ADJECTIVE,
                                         meaning = "예약된",
                                         preContext = "미리 자리를 확보한",
                                     ),
-                                    WordDefinition(
+                                    WordDefinitionCreateObject(
                                         lexicalCategory = LexicalCategoryType.VERB,
                                         meaning = "예약하다",
                                         preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",


### PR DESCRIPTION
- add wordId field on WordDefinition
  - wordId field is needed for join queries (using JPQL)
  - want to treat word as root aggregate, which is guide client to access through the root
- change word's definitions field to mutableList to add definitions without copying
- refactor CreateStudyApplicationTest, ReadStudiesApplicationTest
- fix WordFactory's createWord method according to the relationship changes

https://inoutedu.atlassian.net/browse/IO-64