### PR TITLE
feature: Support Study History

### DIFF
--- a/app/src/main/kotlin/com/inout/apiserver/application/study/ReadStudiesApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/study/ReadStudiesApplication.kt
@@ -17,6 +17,7 @@ class ReadStudiesApplication(
 ) {
     data class Request(
         val userId: UserId,
+        val wordNamePrefix: String?,
         val pageable: Pageable,
     )
 
@@ -26,7 +27,7 @@ class ReadStudiesApplication(
     )
 
     fun run(request: Request): Response {
-        val studies = studyService.getAllByUserId(request.userId, request.pageable)
+        val studies = studyService.getAllByUserId(request.userId, request.wordNamePrefix, request.pageable)
         val wordDefinitionIds = studies.content.map { it.wordDefinitionId }
         val words = wordService.getWordsByWordDefinitionIds(wordDefinitionIds)
         val wordByDefinitionIdMap = mutableMapOf<WordDefinitionId, Word>()

--- a/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
@@ -14,6 +14,7 @@ import com.inout.apiserver.infrastructure.db.user.User
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.LocalDate
@@ -27,17 +28,44 @@ class StudyService(
 ) {
     fun getAllByUserId(
         userId: UserId,
+        wordNamePrefix: String?,
         pageable: Pageable,
-    ): Page<Study> {
-        //  TODO: ignore sort for now
-        val sortIgnoredPageRequest =
-            PageRequest.of(
-                pageable.pageNumber,
-                pageable.pageSize,
-            )
+    ): Page<Study> =
+        when (wordNamePrefix) {
+            null -> {
+                val validSorts = Study.validSorts
+                val sorts = pageable.sort.filter { it.property in validSorts }.toList()
+                val pageRequest =
+                    if (sorts.isNotEmpty()) {
+                        PageRequest.of(
+                            pageable.pageNumber,
+                            pageable.pageSize,
+                            Sort.by(sorts),
+                        )
+                    } else {
+                        PageRequest.of(
+                            pageable.pageNumber,
+                            pageable.pageSize,
+                            Sort.by("due").descending(),
+                        )
+                    }
 
-        return studyRepository.findAllByUserId(userId, sortIgnoredPageRequest)
-    }
+                studyRepository.findAllByUserId(userId, pageRequest)
+            }
+
+            else -> {
+                PageRequest.of(
+                    pageable.pageNumber,
+                    pageable.pageSize,
+                )
+
+                studyRepository.findAllByUserIdAndWordNamePrefix(
+                    userId = userId,
+                    wordNamePrefix = wordNamePrefix,
+                    pageable = pageable,
+                )
+            }
+        }
 
     fun getByUserIdAndWordDefinitionId(
         userId: UserId,

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/Study.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/Study.kt
@@ -78,6 +78,8 @@ data class Study(
                 reviewLogs = emptyList(),
             )
         }
+
+        val validSorts = setOf("createdAt", "due", "lastReview")
     }
 
     fun toFsrsCard() =

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepository.kt
@@ -6,6 +6,7 @@ import com.inout.apiserver.base.alias.WordDefinitionId
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.Instant
 
@@ -37,6 +38,22 @@ interface StudyJpaRepository : JpaRepository<Study, StudyId> {
         userId: UserId,
         wordDefinitionIds: List<WordDefinitionId>,
     ): List<Study>
+
+    @Query(
+        """
+            SELECT s FROM Study s
+            JOIN WordDefinition wd ON s.wordDefinitionId = wd.id
+            JOIN Word w ON wd.wordId = w.id
+            WHERE s.userId = :userId
+              AND LOWER(w.name) LIKE LOWER(CONCAT(:wordNamePrefix, '%'))
+            ORDER BY w.name
+        """,
+    )
+    fun findAllByUserIdAndWordNamePrefix(
+        userId: UserId,
+        wordNamePrefix: String,
+        pageable: Pageable,
+    ): Page<Study>
 }
 
 @Repository

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/StudyController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/StudyController.kt
@@ -50,10 +50,15 @@ class StudyController(
     override fun getStudies(
         @Parameter(hidden = true) @RequestUser user: User,
         @Parameter(hidden = true) pageable: Pageable,
+        @RequestParam(required = false) wordNamePrefix: String?,
     ): ResponseEntity<ResponsePaginationWrapper<StudyWordResponse>> {
         val (count, studyWithWords) =
             readStudiesApplication.run(
-                ReadStudiesApplication.Request(userId = user.id!!, pageable = pageable),
+                ReadStudiesApplication.Request(
+                    userId = user.id!!,
+                    wordNamePrefix = wordNamePrefix,
+                    pageable = pageable,
+                ),
             )
         return ResponseEntity(
             ResponsePaginationWrapper(

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/apiSpec/StudyApiSpec.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/apiSpec/StudyApiSpec.kt
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import java.time.LocalDate
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 
@@ -79,6 +80,32 @@ interface StudyApiSpec {
     @Operation(
         summary = "학습 단어 조회",
         description = "요청자의 단어장에 있는 학습 단어를 조회합니다.",
+        parameters = [
+            Parameter(
+                name = "page",
+                description = "페이지 번호 (0부터 시작)",
+                required = false,
+                example = "0",
+            ),
+            Parameter(
+                name = "size",
+                description = "페이지 크기",
+                required = false,
+                example = "20",
+            ),
+            Parameter(
+                name = "sort",
+                description = "정렬 조건 (createdAt, due, lastReview 지원)",
+                required = false,
+                example = "createdAt,desc",
+            ),
+            Parameter(
+                name = "wordNamePrefix",
+                description = "단어 이름 접두어",
+                required = false,
+                example = "apple",
+            ),
+        ],
         responses = [
             ApiResponse(
                 responseCode = "200",
@@ -90,6 +117,7 @@ interface StudyApiSpec {
     fun getStudies(
         @Parameter(hidden = true) user: User,
         @Parameter(hidden = true) pageable: Pageable,
+        @RequestParam(required = false) wordNamePrefix: String?,
     ): ResponseEntity<ResponsePaginationWrapper<StudyWordResponse>>
 
     @GetMapping("/daily")

--- a/app/src/test/kotlin/com/inout/apiserver/application/study/ReadStudiesApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/study/ReadStudiesApplicationTest.kt
@@ -10,6 +10,7 @@ import com.inout.apiserver.helper.InOutSpringBootTest
 import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeSortedDescendingBy
 import io.kotest.matchers.shouldBe
 import org.springframework.data.domain.PageRequest
 import org.springframework.jdbc.core.JdbcTemplate
@@ -104,20 +105,19 @@ class ReadStudiesApplicationTest(
                 val pageable = PageRequest.of(0, studies.size - 1)
 
                 // when
-                val result = subject.run(ReadStudiesApplication.Request(userId = user!!.id!!, pageable = pageable))
+                val result =
+                    subject.run(
+                        ReadStudiesApplication.Request(
+                            userId = user!!.id!!,
+                            wordNamePrefix = null,
+                            pageable = pageable,
+                        ),
+                    )
 
                 // then
                 result.totalCount shouldBe studies.size.toLong()
                 result.studies.size shouldBe studies.size - 1
-                result.studies.forEachIndexed { index, studyWord ->
-                    studyWord.study shouldBe studies[index]
-                    studyWord.word.id shouldBe words!![index].id
-                    studyWord.word.name shouldBe words!![index].name
-                    studyWord.word.definitions.size shouldBe 1
-                    studyWord.word.definitions
-                        .first()
-                        .id shouldBe studyWord.study.wordDefinitionId
-                }
+                result.studies shouldBeSortedDescendingBy { it.study.due }
             }
         }
     })

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/StartConversationApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/StartConversationApplicationTest.kt
@@ -60,7 +60,7 @@ class StartConversationApplicationTest(
 
         describe("when user is not studying given wordDefinitionId") {
             beforeEach {
-                studyService.getAllByUserId(user!!.id!!, PageRequest.of(0, 10)).totalElements shouldBe 0
+                studyService.getAllByUserId(user!!.id!!, null, PageRequest.of(0, 10)).totalElements shouldBe 0
             }
 
             it("should throw BadRequestException") {

--- a/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyServiceTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/study/StudyServiceTest.kt
@@ -14,12 +14,14 @@ import com.inout.apiserver.infrastructure.db.study.DailyStudySetRepository
 import com.inout.apiserver.infrastructure.db.study.Study
 import com.inout.apiserver.infrastructure.db.user.User
 import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordDefinition
 import com.inout.fsrs.base.plusDays
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeSortedBy
+import io.kotest.matchers.collections.shouldBeSortedDescendingBy
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainAnyOf
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.ranges.shouldBeIn
@@ -27,6 +29,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.jdbc.core.JdbcTemplate
 import java.time.Instant
 import java.time.LocalDate
@@ -58,45 +61,117 @@ class StudyServiceTest(
         }
 
         describe("getAllByUserId") {
+            fun createWords(): List<Word> =
+                listOf(
+                    wordFactory
+                        .createWord(
+                            name = "bank",
+                            wordDefinitions =
+                                listOf(
+                                    WordDefinitionCreateObject(
+                                        lexicalCategory = LexicalCategoryType.NOUN,
+                                        meaning = "은행",
+                                        preContext = "돈을 보관하거나 대출을 해주는 기관",
+                                    ),
+                                ),
+                        ),
+                    wordFactory
+                        .createWord(
+                            name = "book",
+                            wordDefinitions =
+                                listOf(
+                                    WordDefinitionCreateObject(
+                                        lexicalCategory = LexicalCategoryType.NOUN,
+                                        meaning = "책",
+                                        preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+                                    ),
+                                    WordDefinitionCreateObject(
+                                        lexicalCategory = LexicalCategoryType.VERB,
+                                        meaning = "예약하다",
+                                        preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                                    ),
+                                ),
+                        ),
+                    wordFactory
+                        .createWord(
+                            name = "booked",
+                            wordDefinitions =
+                                listOf(
+                                    WordDefinitionCreateObject(
+                                        lexicalCategory = LexicalCategoryType.NOUN,
+                                        meaning = "예약된",
+                                        preContext = "미리 자리를 확보한",
+                                    ),
+                                ),
+                        ),
+                )
+
+            fun createStudies(
+                user: User,
+                wordDefinitions: List<WordDefinition>,
+            ): List<Study> = wordDefinitions.map { studyFactory.createStudy(userId = user.id!!, wordDefinitionId = it.id!!) }
+
             it("should return empty list when there is no study") {
                 // given
                 val pageable = PageRequest.of(0, 10)
 
                 // when
-                val studies = studyService.getAllByUserId(user!!.id!!, pageable)
+                val studies = studyService.getAllByUserId(user!!.id!!, null, pageable)
 
                 // then
                 studies.isEmpty shouldBe true
             }
 
-            it("should return list of studies") {
+            it("should return list of studies with given/default sort") {
                 // given
-                val word =
-                    wordFactory.createWord(
-                        wordDefinitions =
-                            listOf(
-                                WordDefinitionCreateObject(
-                                    lexicalCategory = LexicalCategoryType.NOUN,
-                                    meaning = "책",
-                                    preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
-                                ),
-                                WordDefinitionCreateObject(
-                                    lexicalCategory = LexicalCategoryType.VERB,
-                                    meaning = "예약하다",
-                                    preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
-                                ),
-                            ),
-                    )
-                val studies =
-                    word.definitions.map { studyFactory.createStudy(userId = user!!.id!!, wordDefinitionId = it.id!!) }
+                val words = createWords()
+                createStudies(user!!, words.flatMap { it.definitions })
+
+                // case1: sort by createdAt descending
+                val res1 =
+                    studyService.getAllByUserId(user!!.id!!, null, PageRequest.of(0, 10, Sort.by("createdAt").descending()))
+                res1.totalElements shouldBe 4
+                res1.content shouldBeSortedDescendingBy { it.createdAt!! }
+
+                // case 2: sort by createdAt ascending
+                val res2 =
+                    studyService.getAllByUserId(user!!.id!!, null, PageRequest.of(0, 10, Sort.by("createdAt").ascending()))
+                res2.totalElements shouldBe 4
+                res2.content shouldBeSortedBy { it.createdAt!! }
+
+                // case 3: sort by default (due descending)
+                val res3 =
+                    studyService.getAllByUserId(user!!.id!!, null, PageRequest.of(0, 10))
+                res3.totalElements shouldBe 4
+                res3.content shouldBeSortedDescendingBy { it.due }
+
+                // case 4: sort by invalid sort
+                val res4 =
+                    studyService.getAllByUserId(user!!.id!!, null, PageRequest.of(0, 10, Sort.by("invalid").descending()))
+                res4.totalElements shouldBe 4
+                res4.content shouldBeSortedDescendingBy { it.due }
+            }
+
+            it("should return list of studies with matching prefix") {
+                // given
+                val words = createWords()
+                val studyingWordDefinitions = words.map { it.definitions.first() }
+                createStudies(user!!, studyingWordDefinitions)
+                val prefix = "book"
 
                 // when
-                val res = studyService.getAllByUserId(user!!.id!!, PageRequest.of(0, 10))
+                val res = studyService.getAllByUserId(user!!.id!!, prefix, PageRequest.of(0, 2))
 
                 // then
-                res.totalElements shouldBe 2
-                res.content shouldContainExactly studies
-                res.isLast shouldBe true
+                val expectedWords = words.filter { it.name.startsWith(prefix) }
+                res.totalElements shouldBe expectedWords.size
+                val expectedWordDefinitions =
+                    expectedWords
+                        .flatMap { word -> word.definitions }
+                        .map { wordDefinition -> wordDefinition.id!! }
+                        .filter { wordDefinitionId -> wordDefinitionId in studyingWordDefinitions.map { it.id!! } }
+                res.content.map { it.wordDefinitionId } shouldContainAll expectedWordDefinitions
+                res.content shouldBeSortedBy { expectedWords.find { it.definitions.first().wordId == it.id }!!.name }
             }
         }
 


### PR DESCRIPTION
- add query for finding studies by word's name prefix
  - uses wordNamePrefix directly but is safe from sql injection since bound parameter is used by Hibernate/JPA (treated as string, not executable SQL)
- add optional wordPrefixName parameter on get studies API
- support sort on get studies API

https://inoutedu.atlassian.net/browse/IO-44