### PR TITLE
feat: Add Status to WordDefinition

### DIFF
--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplication.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 @Component
 class AddWordDefinitionApplication(
     private val wordService: WordService,
-    // injected wordRepository here to avoid adding update on word on commonly used WordService
+    // injected wordRepository here to avoid adding update on word method on commonly used WordService
     private val wordRepository: WordRepository,
 ) {
     data class Request(

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplication.kt
@@ -2,6 +2,7 @@ package com.inout.apiserver.application.word.admin
 
 import com.inout.apiserver.base.alias.WordId
 import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.base.enums.StatusType
 import com.inout.apiserver.domain.word.WordDefinitionCreateObject
 import com.inout.apiserver.domain.word.WordService
 import com.inout.apiserver.error.ConflictException
@@ -42,7 +43,11 @@ class AddWordDefinitionApplication(
                 code = "WORD_4",
             )
         word.definitions.forEach { wordDefinition ->
-            if (wordDefinition.meaning == request.meaning && wordDefinition.lexicalCategory == request.lexicalCategory) {
+            if (
+                wordDefinition.status != StatusType.REMOVED &&
+                wordDefinition.meaning == request.meaning &&
+                wordDefinition.lexicalCategory == request.lexicalCategory
+            ) {
                 throw ConflictException(
                     message = "Word definition already exists",
                     code = "WORD_5",

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplication.kt
@@ -1,0 +1,76 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.alias.WordId
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.domain.word.WordDefinitionCreateObject
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.ConflictException
+import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordDefinition
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import org.springframework.stereotype.Component
+
+@Component
+class AddWordDefinitionApplication(
+    private val wordService: WordService,
+    // injected wordRepository here to avoid adding update on word on commonly used WordService
+    private val wordRepository: WordRepository,
+) {
+    data class Request(
+        val wordId: WordId,
+        val lexicalCategory: LexicalCategoryType,
+        val meaning: String,
+        val preContext: String,
+    )
+
+    data class Response(
+        val word: Word,
+    )
+
+    fun run(request: Request): Response {
+        val word = findAndValidateWord(request)
+        val updatedWord = updateWord(word, request)
+
+        return Response(word = updatedWord)
+    }
+
+    private fun findAndValidateWord(request: Request): Word {
+        val word =
+            wordService.getWordById(request.wordId) ?: throw NotFoundException(
+                message = "Word not found",
+                code = "WORD_4",
+            )
+        word.definitions.forEach { wordDefinition ->
+            if (wordDefinition.meaning == request.meaning && wordDefinition.lexicalCategory == request.lexicalCategory) {
+                throw ConflictException(
+                    message = "Word definition already exists",
+                    code = "WORD_5",
+                )
+            }
+        }
+        return word
+    }
+
+    private fun updateWord(
+        word: Word,
+        request: Request,
+    ): Word {
+        word.addDefinitions(
+            listOf(
+                WordDefinition.fromCreateObject(
+                    createObject =
+                        WordDefinitionCreateObject(
+                            lexicalCategory = request.lexicalCategory,
+                            meaning = request.meaning,
+                            preContext = request.preContext,
+                        ),
+                    word = word,
+                ),
+            ),
+        )
+
+        val updatedWord = wordRepository.save(word)
+        return updatedWord
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/ApproveWordDefinitionApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/ApproveWordDefinitionApplication.kt
@@ -1,0 +1,61 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.base.alias.WordId
+import com.inout.apiserver.base.enums.StatusType
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ApproveWordDefinitionApplication(
+    private val wordService: WordService,
+    // injected wordRepository here to avoid adding update on word method on commonly used WordService
+    private val wordRepository: WordRepository,
+) {
+    data class Request(
+        val wordId: WordId,
+        val wordDefinitionId: WordDefinitionId,
+    )
+
+    data class Response(
+        val word: Word,
+    )
+
+    fun run(request: Request): Response {
+        val word = findAndValidateWord(request)
+        val updatedWord = approveWordDefinition(word, request)
+
+        return Response(word = updatedWord)
+    }
+
+    private fun findAndValidateWord(request: Request): Word {
+        val word = wordService.getWordById(request.wordId)
+        val wordDefinition =
+            word?.definitions?.find { it.id == request.wordDefinitionId }
+                ?: throw NotFoundException(
+                    message = "Word definition not found",
+                    code = "WORD_4",
+                )
+        if (wordDefinition.status != StatusType.PENDING) {
+            throw BadRequestException(
+                message = "Cannot approve word definition that is not pending",
+                code = "WORD_6",
+            )
+        }
+
+        return word
+    }
+
+    private fun approveWordDefinition(
+        word: Word,
+        request: Request,
+    ): Word {
+        word.approveDefinition(request.wordDefinitionId)
+        wordRepository.save(word)
+        return word
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/ApproveWordDefinitionApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/ApproveWordDefinitionApplication.kt
@@ -55,7 +55,6 @@ class ApproveWordDefinitionApplication(
         request: Request,
     ): Word {
         word.approveDefinition(request.wordDefinitionId)
-        wordRepository.save(word)
-        return word
+        return wordRepository.save(word)
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/CreateWordManualApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/CreateWordManualApplication.kt
@@ -1,0 +1,61 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.domain.word.WordCreateObject
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.ConflictException
+import com.inout.apiserver.infrastructure.db.word.Word
+import org.springframework.stereotype.Component
+
+@Component
+class CreateWordManualApplication(
+    private val wordService: WordService,
+) {
+    data class Request(
+        val name: String,
+        val fromLanguage: LanguageType,
+        val toLanguage: LanguageType,
+    )
+
+    data class Response(
+        val word: Word,
+    )
+
+    fun run(request: Request): Response {
+        validateWordDoesNotExist(
+            name = request.name,
+            fromLanguage = request.fromLanguage,
+            toLanguage = request.toLanguage,
+        )
+
+        return Response(word = createWord(request))
+    }
+
+    private fun validateWordDoesNotExist(
+        name: String,
+        fromLanguage: LanguageType,
+        toLanguage: LanguageType,
+    ) {
+        wordService
+            .getWordByNameAndFromLanguageAndToLanguage(
+                name = name,
+                fromLanguage = fromLanguage,
+                toLanguage = toLanguage,
+            )?.let {
+                throw ConflictException(message = "Word already exists", code = "WORD_1")
+            }
+    }
+
+    private fun createWord(request: Request): Word {
+        val createdWord =
+            wordService.createWord(
+                WordCreateObject(
+                    name = request.name,
+                    fromLanguage = request.fromLanguage,
+                    toLanguage = request.toLanguage,
+                    definitions = emptyList(),
+                ),
+            )
+        return createdWord
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/application/word/admin/DeleteWordDefinitionApplication.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/application/word/admin/DeleteWordDefinitionApplication.kt
@@ -1,0 +1,74 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.alias.WordDefinitionId
+import com.inout.apiserver.base.alias.WordId
+import com.inout.apiserver.base.enums.StatusType
+import com.inout.apiserver.domain.study.StudyService
+import com.inout.apiserver.domain.word.WordService
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import org.springframework.stereotype.Component
+
+@Component
+class DeleteWordDefinitionApplication(
+    private val wordService: WordService,
+    private val studyService: StudyService,
+    // injected wordRepository here to avoid adding update on word method on commonly used WordService
+    private val wordRepository: WordRepository,
+) {
+    data class Request(
+        val wordId: WordId,
+        val wordDefinitionId: WordDefinitionId,
+    )
+
+    data class Response(
+        val word: Word,
+    )
+
+    fun run(request: Request): Response {
+        val word = findAndValidateWordDefinition(request)
+        val updatedWord = deleteWordDefinition(word, request)
+        return Response(word = updatedWord)
+    }
+
+    private fun findAndValidateWordDefinition(request: Request): Word {
+        val word = wordService.getWordById(request.wordId)
+        val wordDefinition =
+            word?.let {
+                it.definitions.find { definition -> definition.id == request.wordDefinitionId }
+            } ?: throw NotFoundException(
+                message = "Word definition not found",
+                code = "WORD_4",
+            )
+
+        val deletable =
+            when (wordDefinition.status) {
+                // if it is pending, it can be deleted
+                StatusType.PENDING -> true
+                // if it is approved but not used, it can be deleted
+                StatusType.LIVE -> !studyService.existsStudyByWordDefinitionId(request.wordDefinitionId)
+                // otherwise(if already deleted), it cannot be deleted
+                else -> false
+            }
+
+        if (!deletable) {
+            throw BadRequestException(
+                message = "Cannot delete word definition that is not pending or not used",
+                code = "WORD_7",
+            )
+        }
+
+        return word
+    }
+
+    private fun deleteWordDefinition(
+        word: Word,
+        request: Request,
+    ): Word {
+        word.removeDefinition(request.wordDefinitionId)
+        wordRepository.save(word)
+        return word
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/base/enums/StatusType.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/base/enums/StatusType.kt
@@ -1,0 +1,7 @@
+package com.inout.apiserver.base.enums
+
+enum class StatusType {
+    PENDING,
+    LIVE,
+    REMOVED,
+}

--- a/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/domain/study/StudyService.kt
@@ -193,4 +193,7 @@ class StudyService(
         userId: UserId,
         wordDefinitionIds: List<WordDefinitionId>,
     ): List<Study> = studyRepository.findAllByUserIdAndWordDefinitionIdIn(userId, wordDefinitionIds)
+
+    fun existsStudyByWordDefinitionId(wordDefinitionId: WordDefinitionId): Boolean =
+        studyRepository.existsByWordDefinitionId(wordDefinitionId)
 }

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepository.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/study/StudyRepository.kt
@@ -54,6 +54,8 @@ interface StudyJpaRepository : JpaRepository<Study, StudyId> {
         wordNamePrefix: String,
         pageable: Pageable,
     ): Page<Study>
+
+    fun existsByWordDefinitionId(wordDefinitionId: WordDefinitionId): Boolean
 }
 
 @Repository

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
@@ -1,8 +1,10 @@
 package com.inout.apiserver.infrastructure.db.word
 
 import com.google.common.collect.Iterables
+import com.inout.apiserver.base.alias.WordDefinitionId
 import com.inout.apiserver.base.alias.WordId
 import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.base.enums.StatusType
 import com.inout.apiserver.domain.word.WordCreateObject
 import com.inout.apiserver.infrastructure.db.TimestampedEntity
 import jakarta.persistence.CascadeType
@@ -53,6 +55,18 @@ data class Word(
 
     fun addDefinitions(definitions: List<WordDefinition>): Word {
         this.definitions.addAll(definitions)
+
+        return this
+    }
+
+    fun approveDefinition(definitionId: WordDefinitionId): Word {
+        definitions
+            .indexOfFirst { definition -> definition.id == definitionId }
+            .takeIf { it != -1 && definitions[it].status == StatusType.PENDING }
+            ?.let { targetIndex ->
+                val updatedDefinition = definitions[targetIndex].copy(status = StatusType.LIVE)
+                definitions[targetIndex] = updatedDefinition
+            }
 
         return this
     }

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/Word.kt
@@ -71,6 +71,18 @@ data class Word(
         return this
     }
 
+    fun removeDefinition(wordDefinitionId: WordDefinitionId): Word {
+        definitions
+            .indexOfFirst { definition -> definition.id == wordDefinitionId }
+            .takeIf { it != -1 }
+            ?.let { targetIndex ->
+                val removedDefinition = definitions[targetIndex].copy(status = StatusType.REMOVED)
+                definitions[targetIndex] = removedDefinition
+            }
+
+        return this
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordDefinition.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/infrastructure/db/word/WordDefinition.kt
@@ -3,6 +3,7 @@ package com.inout.apiserver.infrastructure.db.word
 import com.inout.apiserver.base.alias.WordDefinitionId
 import com.inout.apiserver.base.alias.WordId
 import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.base.enums.StatusType
 import com.inout.apiserver.domain.word.WordDefinitionCreateObject
 import com.inout.apiserver.infrastructure.db.TimestampedEntity
 import jakarta.persistence.Column
@@ -26,6 +27,8 @@ data class WordDefinition(
     val lexicalCategory: LexicalCategoryType,
     val meaning: String,
     val preContext: String,
+    @Enumerated(EnumType.STRING)
+    val status: StatusType = StatusType.PENDING,
 ) : TimestampedEntity() {
     companion object {
         fun fromCreateObject(
@@ -37,6 +40,7 @@ data class WordDefinition(
                 lexicalCategory = createObject.lexicalCategory,
                 meaning = createObject.meaning,
                 preContext = createObject.preContext,
+                status = StatusType.PENDING,
             )
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/WordController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/WordController.kt
@@ -1,32 +1,21 @@
 package com.inout.apiserver.interfaces.web.v1
 
-import com.inout.apiserver.application.word.CreateSentenceApplication
-import com.inout.apiserver.application.word.CreateWordApplication
 import com.inout.apiserver.application.word.ReadWordsApplication
 import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.config.web.RequestUser
-import com.inout.apiserver.error.HttpException
 import com.inout.apiserver.infrastructure.db.user.User
-import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
 import com.inout.apiserver.interfaces.web.v1.response.DictionaryWordWithDefinitionsResponse
 import com.inout.apiserver.interfaces.web.v1.response.ResponsePaginationWrapper
-import com.inout.apiserver.interfaces.web.v1.response.WordResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import jakarta.validation.Valid
-import org.jobrunr.scheduling.JobScheduler
 import org.springdoc.core.converters.models.PageableAsQueryParam
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -34,78 +23,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v1/words")
 class WordController(
-    private val createWordApplication: CreateWordApplication,
     private val readWordsApplication: ReadWordsApplication,
-    private val createSentenceApplication: CreateSentenceApplication,
-    private val jobScheduler: JobScheduler,
 ) {
-    @PostMapping
-    @Operation(
-        summary = "사전 단어 등록",
-        description = "사전 단어 등록을 요청합니다.",
-        requestBody =
-            io.swagger.v3.oas.annotations.parameters.RequestBody(
-                description = "단어 생성 요청값",
-                required = true,
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = CreateWordRequest::class),
-                    ),
-                ],
-            ),
-        responses = [
-            ApiResponse(
-                responseCode = "201",
-                description = "사전 단어 등록 성공",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = WordResponse::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "400",
-                description = "사전 정의를 찾을 수 없음 (code: WORD_3)",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = HttpException::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "사전 단어 등록 실패 (code: WORD_1) - 이미 존재하는 단어",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = HttpException::class),
-                    ),
-                ],
-            ),
-        ],
-    )
-    fun createWord(
-        @RequestBody @Valid request: CreateWordRequest,
-    ): ResponseEntity<WordResponse> {
-        val result =
-            createWordApplication.run(
-                CreateWordApplication.Request(
-                    name = request.name,
-                    fromLanguage = request.fromLanguage,
-                    toLanguage = request.toLanguage,
-                ),
-            )
-        jobScheduler.enqueue { createSentenceApplication.run(CreateSentenceApplication.Request(wordId = result.word.id!!)) }
-
-        return ResponseEntity(
-            WordResponse.of(result.word),
-            CREATED,
-        )
-    }
-
     @GetMapping("/definitions")
     @PageableAsQueryParam
     @Operation(

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
@@ -5,6 +5,7 @@ import com.inout.apiserver.application.word.CreateWordApplication
 import com.inout.apiserver.application.word.admin.AddWordDefinitionApplication
 import com.inout.apiserver.application.word.admin.ApproveWordDefinitionApplication
 import com.inout.apiserver.application.word.admin.CreateWordManualApplication
+import com.inout.apiserver.application.word.admin.DeleteWordDefinitionApplication
 import com.inout.apiserver.error.HttpException
 import com.inout.apiserver.interfaces.web.v1.request.AddWordDefinitionRequest
 import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
@@ -17,7 +18,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
 import org.jobrunr.scheduling.JobScheduler
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.OK
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -33,6 +36,7 @@ class AdminWordController(
     private val createWordManualApplication: CreateWordManualApplication,
     private val addWordDefinitionApplication: AddWordDefinitionApplication,
     private val approveWordDefinitionApplication: ApproveWordDefinitionApplication,
+    private val deleteWordDefinitionApplication: DeleteWordDefinitionApplication,
     private val jobScheduler: JobScheduler,
 ) {
     @PostMapping
@@ -276,5 +280,57 @@ class AdminWordController(
             )
 
         return ResponseEntity.ok(WordWithDefinitionsResponse.of(result.word))
+    }
+
+    @DeleteMapping("/{wordId}/definitions/{wordDefinitionId}")
+    @Operation(
+        summary = "사전 단어 정의 삭제",
+        description = "사전 단어 정의 삭제를 요청합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "사전 단어 정의 삭제 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = WordWithDefinitionsResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "사전 단어 정의 삭제 실패 (code: WORD_7) - 삭제 할 수 없는 상태",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사전 정의를 찾을 수 없음 (code: WORD_4)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun deleteWordDefinition(
+        @PathVariable wordId: Long,
+        @PathVariable wordDefinitionId: Long,
+    ): ResponseEntity<WordWithDefinitionsResponse> {
+        val result =
+            deleteWordDefinitionApplication.run(
+                DeleteWordDefinitionApplication.Request(
+                    wordId = wordId,
+                    wordDefinitionId = wordDefinitionId,
+                ),
+            )
+
+        return ResponseEntity(WordWithDefinitionsResponse.of(result.word), OK)
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
@@ -2,10 +2,13 @@ package com.inout.apiserver.interfaces.web.v1.admin
 
 import com.inout.apiserver.application.word.CreateSentenceApplication
 import com.inout.apiserver.application.word.CreateWordApplication
+import com.inout.apiserver.application.word.admin.AddWordDefinitionApplication
 import com.inout.apiserver.application.word.admin.CreateWordManualApplication
 import com.inout.apiserver.error.HttpException
+import com.inout.apiserver.interfaces.web.v1.request.AddWordDefinitionRequest
 import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
 import com.inout.apiserver.interfaces.web.v1.response.WordResponse
+import com.inout.apiserver.interfaces.web.v1.response.WordWithDefinitionsResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -14,6 +17,7 @@ import jakarta.validation.Valid
 import org.jobrunr.scheduling.JobScheduler
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,11 +29,12 @@ class AdminWordController(
     private val createWordApplication: CreateWordApplication,
     private val createSentenceApplication: CreateSentenceApplication,
     private val createWordManualApplication: CreateWordManualApplication,
+    private val addWordDefinitionApplication: AddWordDefinitionApplication,
     private val jobScheduler: JobScheduler,
 ) {
     @PostMapping
     @Operation(
-        summary = "사전 단어 등록",
+        summary = "사전 단어 등록 (AI)",
         description = "사전 단어 등록을 요청합니다.",
         requestBody =
             io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -146,6 +151,74 @@ class AdminWordController(
 
         return ResponseEntity(
             WordResponse.of(result.word),
+            CREATED,
+        )
+    }
+
+    @PostMapping("/{wordId}/definitions")
+    @Operation(
+        summary = "사전 단어 정의 추가",
+        description = "사전 단어 정의 추가를 요청합니다.",
+        requestBody =
+            io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "단어 정의 추가 요청값",
+                required = true,
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = AddWordDefinitionRequest::class),
+                    ),
+                ],
+            ),
+        responses = [
+            ApiResponse(
+                responseCode = "201",
+                description = "사전 단어 정의 추가 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = WordWithDefinitionsResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사전 정의를 찾을 수 없음 (code: WORD_4)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "사전 단어 정의 추가 실패 (code: WORD_5) - 이미 존재하는 단어 정의",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun addDefinitionToWord(
+        @RequestBody @Valid request: AddWordDefinitionRequest,
+        @PathVariable wordId: Long,
+    ): ResponseEntity<WordWithDefinitionsResponse> {
+        val result =
+            addWordDefinitionApplication.run(
+                AddWordDefinitionApplication.Request(
+                    wordId = wordId,
+                    lexicalCategory = request.lexicalCategory,
+                    meaning = request.meaning,
+                    preContext = request.preContext,
+                ),
+            )
+
+        return ResponseEntity(
+            WordWithDefinitionsResponse.of(result.word),
             CREATED,
         )
     }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
@@ -279,6 +279,8 @@ class AdminWordController(
                 ),
             )
 
+        jobScheduler.enqueue { createSentenceApplication.createSentencesFor(wordId, wordDefinitionId) }
+
         return ResponseEntity.ok(WordWithDefinitionsResponse.of(result.word))
     }
 

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
@@ -1,0 +1,152 @@
+package com.inout.apiserver.interfaces.web.v1.admin
+
+import com.inout.apiserver.application.word.CreateSentenceApplication
+import com.inout.apiserver.application.word.CreateWordApplication
+import com.inout.apiserver.application.word.admin.CreateWordManualApplication
+import com.inout.apiserver.error.HttpException
+import com.inout.apiserver.interfaces.web.v1.request.CreateWordRequest
+import com.inout.apiserver.interfaces.web.v1.response.WordResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.jobrunr.scheduling.JobScheduler
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/admin/v1/words")
+class AdminWordController(
+    private val createWordApplication: CreateWordApplication,
+    private val createSentenceApplication: CreateSentenceApplication,
+    private val createWordManualApplication: CreateWordManualApplication,
+    private val jobScheduler: JobScheduler,
+) {
+    @PostMapping
+    @Operation(
+        summary = "사전 단어 등록",
+        description = "사전 단어 등록을 요청합니다.",
+        requestBody =
+            io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "단어 생성 요청값",
+                required = true,
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CreateWordRequest::class),
+                    ),
+                ],
+            ),
+        responses = [
+            ApiResponse(
+                responseCode = "201",
+                description = "사전 단어 등록 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = WordResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "사전 정의를 찾을 수 없음 (code: WORD_3)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "사전 단어 등록 실패 (code: WORD_1) - 이미 존재하는 단어",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun createWord(
+        @RequestBody @Valid request: CreateWordRequest,
+    ): ResponseEntity<WordResponse> {
+        val result =
+            createWordApplication.run(
+                CreateWordApplication.Request(
+                    name = request.name,
+                    fromLanguage = request.fromLanguage,
+                    toLanguage = request.toLanguage,
+                ),
+            )
+        jobScheduler.enqueue { createSentenceApplication.run(CreateSentenceApplication.Request(wordId = result.word.id!!)) }
+
+        return ResponseEntity(
+            WordResponse.of(result.word),
+            CREATED,
+        )
+    }
+
+    @PostMapping("/manual")
+    @Operation(
+        summary = "사전 단어 수동 등록",
+        description = "사전 단어 수동 등록을 요청합니다.",
+        requestBody =
+            io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "단어 생성 요청값",
+                required = true,
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CreateWordRequest::class),
+                    ),
+                ],
+            ),
+        responses = [
+            ApiResponse(
+                responseCode = "201",
+                description = "사전 단어 등록 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = WordResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "사전 단어 등록 실패 (code: WORD_1) - 이미 존재하는 단어",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun createWordManual(
+        @RequestBody @Valid request: CreateWordRequest,
+    ): ResponseEntity<WordResponse> {
+        val result =
+            createWordManualApplication.run(
+                CreateWordManualApplication.Request(
+                    name = request.name,
+                    fromLanguage = request.fromLanguage,
+                    toLanguage = request.toLanguage,
+                ),
+            )
+
+        return ResponseEntity(
+            WordResponse.of(result.word),
+            CREATED,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/admin/AdminWordController.kt
@@ -3,6 +3,7 @@ package com.inout.apiserver.interfaces.web.v1.admin
 import com.inout.apiserver.application.word.CreateSentenceApplication
 import com.inout.apiserver.application.word.CreateWordApplication
 import com.inout.apiserver.application.word.admin.AddWordDefinitionApplication
+import com.inout.apiserver.application.word.admin.ApproveWordDefinitionApplication
 import com.inout.apiserver.application.word.admin.CreateWordManualApplication
 import com.inout.apiserver.error.HttpException
 import com.inout.apiserver.interfaces.web.v1.request.AddWordDefinitionRequest
@@ -17,6 +18,7 @@ import jakarta.validation.Valid
 import org.jobrunr.scheduling.JobScheduler
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -30,6 +32,7 @@ class AdminWordController(
     private val createSentenceApplication: CreateSentenceApplication,
     private val createWordManualApplication: CreateWordManualApplication,
     private val addWordDefinitionApplication: AddWordDefinitionApplication,
+    private val approveWordDefinitionApplication: ApproveWordDefinitionApplication,
     private val jobScheduler: JobScheduler,
 ) {
     @PostMapping
@@ -221,5 +224,57 @@ class AdminWordController(
             WordWithDefinitionsResponse.of(result.word),
             CREATED,
         )
+    }
+
+    @PatchMapping("/{wordId}/definitions/{wordDefinitionId}/approve")
+    @Operation(
+        summary = "사전 단어 정의 승인",
+        description = "사전 단어 정의 승인을 요청합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "사전 단어 정의 승인 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = WordWithDefinitionsResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "사전 단어 정의 승인 실패 (code: WORD_6) - 승인 할 수 없는 상태",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사전 정의를 찾을 수 없음 (code: WORD_4)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = HttpException::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun approveWordDefinition(
+        @PathVariable wordId: Long,
+        @PathVariable wordDefinitionId: Long,
+    ): ResponseEntity<WordWithDefinitionsResponse> {
+        val result =
+            approveWordDefinitionApplication.run(
+                ApproveWordDefinitionApplication.Request(
+                    wordId = wordId,
+                    wordDefinitionId = wordDefinitionId,
+                ),
+            )
+
+        return ResponseEntity.ok(WordWithDefinitionsResponse.of(result.word))
     }
 }

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/request/AddWordDefinitionRequest.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/request/AddWordDefinitionRequest.kt
@@ -1,0 +1,20 @@
+package com.inout.apiserver.interfaces.web.v1.request
+
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+
+data class AddWordDefinitionRequest(
+    @Schema(description = "추가할 단어 정의의 품사", example = "NOUN", requiredMode = Schema.RequiredMode.REQUIRED)
+    val lexicalCategory: LexicalCategoryType,
+    @field:NotEmpty
+    @Schema(description = "단어 정의", example = "책", requiredMode = Schema.RequiredMode.REQUIRED)
+    val meaning: String,
+    @field:NotEmpty
+    @Schema(
+        description = "단어 정의의 문맥",
+        example = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val preContext: String,
+)

--- a/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordDefinitionResponse.kt
+++ b/app/src/main/kotlin/com/inout/apiserver/interfaces/web/v1/response/WordDefinitionResponse.kt
@@ -1,6 +1,7 @@
 package com.inout.apiserver.interfaces.web.v1.response
 
 import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.base.enums.StatusType
 import com.inout.apiserver.infrastructure.db.word.WordDefinition
 
 data class WordDefinitionResponse(
@@ -8,6 +9,7 @@ data class WordDefinitionResponse(
     val lexicalCategory: LexicalCategoryType,
     val meaning: String,
     val preContext: String,
+    val status: StatusType,
 ) {
     companion object {
         fun of(wordDefinition: WordDefinition): WordDefinitionResponse =
@@ -16,6 +18,7 @@ data class WordDefinitionResponse(
                 lexicalCategory = wordDefinition.lexicalCategory,
                 meaning = wordDefinition.meaning,
                 preContext = wordDefinition.preContext,
+                status = wordDefinition.status,
             )
     }
 }

--- a/app/src/main/resources/db/migration/V0016__AddStatusToWordDefinition.sql
+++ b/app/src/main/resources/db/migration/V0016__AddStatusToWordDefinition.sql
@@ -1,0 +1,2 @@
+alter table word_definitions
+    add column status varchar(255) not null default 'PENDING';

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplicationTest.kt
@@ -1,0 +1,94 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.base.enums.StatusType
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.error.ConflictException
+import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.word.Word
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.jdbc.core.JdbcTemplate
+
+@InOutSpringBootTest
+class AddWordDefinitionApplicationTest(
+    private val subject: AddWordDefinitionApplication,
+    // factories
+    private val wordFactory: WordFactory,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when word does not exist") {
+            it("should throw NotFoundException") {
+                // given
+                val request =
+                    AddWordDefinitionApplication.Request(
+                        wordId = 1L,
+                        lexicalCategory = LexicalCategoryType.NOUN,
+                        meaning = "책",
+                        preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+                    )
+
+                // when
+                val exception = shouldThrow<NotFoundException> { subject.run(request) }
+
+                // then
+                exception.message shouldBe "Word not found"
+                exception.code shouldBe "WORD_4"
+            }
+        }
+
+        describe("when word exists") {
+            var word: Word? = null
+
+            beforeEach {
+                word = wordFactory.createWord()
+            }
+
+            it("should throw ConflictException when definition already exists") {
+                // given
+                val request =
+                    AddWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        lexicalCategory = LexicalCategoryType.NOUN,
+                        meaning = "책",
+                        preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
+                    )
+
+                // when
+                val exception = shouldThrow<ConflictException> { subject.run(request) }
+
+                // then
+                exception.message shouldBe "Word definition already exists"
+                exception.code shouldBe "WORD_5"
+            }
+
+            it("should add definition to word") {
+                // given
+                val request =
+                    AddWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        lexicalCategory = LexicalCategoryType.VERB,
+                        meaning = "예약하다",
+                        preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                    )
+
+                // when
+                val response = subject.run(request)
+
+                // then
+                response.word.definitions.size shouldBe 2
+                response.word.definitions[1].lexicalCategory shouldBe request.lexicalCategory
+                response.word.definitions[1].meaning shouldBe request.meaning
+                response.word.definitions[1].preContext shouldBe request.preContext
+                response.word.definitions[1].status shouldBe StatusType.PENDING
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/admin/AddWordDefinitionApplicationTest.kt
@@ -8,6 +8,7 @@ import com.inout.apiserver.error.NotFoundException
 import com.inout.apiserver.extension.cleanUp
 import com.inout.apiserver.helper.InOutSpringBootTest
 import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -18,6 +19,8 @@ class AddWordDefinitionApplicationTest(
     private val subject: AddWordDefinitionApplication,
     // factories
     private val wordFactory: WordFactory,
+    // repositories
+    private val wordRepository: WordRepository,
     // etc
     private val jdbcTemplate: JdbcTemplate,
 ) : DescribeSpec({
@@ -78,6 +81,29 @@ class AddWordDefinitionApplicationTest(
                         lexicalCategory = LexicalCategoryType.VERB,
                         meaning = "예약하다",
                         preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                    )
+
+                // when
+                val response = subject.run(request)
+
+                // then
+                response.word.definitions.size shouldBe 2
+                response.word.definitions[1].lexicalCategory shouldBe request.lexicalCategory
+                response.word.definitions[1].meaning shouldBe request.meaning
+                response.word.definitions[1].preContext shouldBe request.preContext
+                response.word.definitions[1].status shouldBe StatusType.PENDING
+            }
+
+            it("should add definition to word if conflict definition is removed") {
+                // given
+                word!!.removeDefinition(wordDefinitionId = word!!.definitions.first().id!!)
+                word = wordRepository.save(word!!)
+                val request =
+                    AddWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        lexicalCategory = LexicalCategoryType.NOUN,
+                        meaning = "책",
+                        preContext = "정보를 얻거나 즐거움을 얻기 위해 읽는 인쇄물",
                     )
 
                 // when

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/admin/ApproveWordDefinitionApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/admin/ApproveWordDefinitionApplicationTest.kt
@@ -1,0 +1,119 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.base.enums.StatusType
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordDefinition
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.jdbc.core.JdbcTemplate
+
+@InOutSpringBootTest
+class ApproveWordDefinitionApplicationTest(
+    private val subject: ApproveWordDefinitionApplication,
+    // factories
+    private val wordFactory: WordFactory,
+    // repositories
+    private val wordRepository: WordRepository,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        var word: Word? = null
+        var wordDefinitionId = 0L
+
+        beforeEach {
+            word = wordFactory.createWord()
+            wordDefinitionId = word!!.definitions.first().id!!
+        }
+
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when wordDefinitionId of wordId does not exist") {
+            it("should throw NotFoundException") {
+                // given
+                val requests =
+                    listOf(
+                        ApproveWordDefinitionApplication.Request(
+                            wordId = word!!.id!!,
+                            wordDefinitionId = 9999L,
+                        ),
+                        ApproveWordDefinitionApplication.Request(
+                            wordId = 9999L,
+                            wordDefinitionId = wordDefinitionId,
+                        ),
+                    )
+
+                // when & then
+                requests.forEach { request ->
+                    val exception = shouldThrow<NotFoundException> { subject.run(request) }
+
+                    exception.message shouldBe "Word definition not found"
+                    exception.code shouldBe "WORD_4"
+                }
+            }
+        }
+
+        describe("when wordId and wordDefinitionId exists but is not pending") {
+            it("should throw BadRequestException") {
+                // given
+                val request =
+                    ApproveWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        wordDefinitionId = wordDefinitionId,
+                    )
+
+                // when
+                val exception = shouldThrow<BadRequestException> { subject.run(request) }
+
+                // then
+                exception.message shouldBe "Cannot approve word definition that is not pending"
+                exception.code shouldBe "WORD_6"
+            }
+        }
+
+        describe("when wordId and wordDefinitionId exists and is pending") {
+            it("should approve word definition") {
+                // given
+                word!!.addDefinitions(
+                    listOf(
+                        WordDefinition(
+                            wordId = word!!.id!!,
+                            lexicalCategory = LexicalCategoryType.VERB,
+                            meaning = "예약하다",
+                            preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                        ),
+                    ),
+                )
+                val updatedWord = wordRepository.save(word!!)
+                wordDefinitionId = updatedWord.definitions.last().id!!
+                updatedWord.definitions.last().status shouldBe StatusType.PENDING
+                val request =
+                    ApproveWordDefinitionApplication.Request(
+                        wordId = updatedWord.id!!,
+                        wordDefinitionId = wordDefinitionId,
+                    )
+
+                // when
+                val response = subject.run(request)
+
+                // then
+                response.word.id shouldBe updatedWord.id
+                response.word.definitions.size shouldBe updatedWord.definitions.size
+                response.word.definitions
+                    .last()
+                    .id shouldBe wordDefinitionId
+                response.word.definitions
+                    .last()
+                    .status shouldBe StatusType.LIVE
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/admin/CreateWordManualApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/admin/CreateWordManualApplicationTest.kt
@@ -1,0 +1,74 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.enums.LanguageType
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.error.ConflictException
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.word.Word
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.jdbc.core.JdbcTemplate
+
+@InOutSpringBootTest
+class CreateWordManualApplicationTest(
+    private val subject: CreateWordManualApplication,
+    // factories
+    private val wordFactory: WordFactory,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when word already exists") {
+            var word: Word? = null
+
+            beforeEach {
+                word = wordFactory.createWord()
+            }
+
+            it("should throw ConflictException") {
+                // given
+                val request =
+                    CreateWordManualApplication.Request(
+                        name = word!!.name,
+                        fromLanguage = word!!.fromLanguage,
+                        toLanguage = word!!.toLanguage,
+                    )
+
+                // when
+                val exception =
+                    shouldThrow<ConflictException> {
+                        subject.run(request)
+                    }
+
+                // then
+                exception.message shouldBe "Word already exists"
+                exception.code shouldBe "WORD_1"
+            }
+        }
+
+        describe("when word does not exist") {
+            it("should create word") {
+                // given
+                val request =
+                    CreateWordManualApplication.Request(
+                        name = "apple",
+                        fromLanguage = LanguageType.ENGLISH,
+                        toLanguage = LanguageType.KOREAN,
+                    )
+
+                // when
+                val response = subject.run(request)
+
+                // then
+                response.word.name shouldBe request.name
+                response.word.fromLanguage shouldBe request.fromLanguage
+                response.word.toLanguage shouldBe request.toLanguage
+                response.word.definitions shouldBe emptyList()
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/application/word/admin/DeleteWordDefinitionApplicationTest.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/application/word/admin/DeleteWordDefinitionApplicationTest.kt
@@ -1,0 +1,159 @@
+package com.inout.apiserver.application.word.admin
+
+import com.inout.apiserver.base.enums.LexicalCategoryType
+import com.inout.apiserver.base.enums.StatusType
+import com.inout.apiserver.domain.study.StudyFactory
+import com.inout.apiserver.domain.user.UserFactory
+import com.inout.apiserver.domain.word.WordFactory
+import com.inout.apiserver.error.BadRequestException
+import com.inout.apiserver.error.NotFoundException
+import com.inout.apiserver.extension.cleanUp
+import com.inout.apiserver.helper.InOutSpringBootTest
+import com.inout.apiserver.infrastructure.db.word.Word
+import com.inout.apiserver.infrastructure.db.word.WordDefinition
+import com.inout.apiserver.infrastructure.db.word.WordRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.jdbc.core.JdbcTemplate
+
+@InOutSpringBootTest
+class DeleteWordDefinitionApplicationTest(
+    private val subject: DeleteWordDefinitionApplication,
+    // factories
+    private val wordFactory: WordFactory,
+    private val userFactory: UserFactory,
+    private val studyFactory: StudyFactory,
+    // repositories
+    private val wordRepository: WordRepository,
+    // etc
+    private val jdbcTemplate: JdbcTemplate,
+) : DescribeSpec({
+        var word: Word? = null
+        var wordDefinitionId = 0L
+
+        beforeEach {
+            word = wordFactory.createWord()
+            wordDefinitionId = word!!.definitions.first().id!!
+        }
+
+        afterEach {
+            jdbcTemplate.cleanUp()
+        }
+
+        describe("when wordDefinitionId of wordId does not exist") {
+            it("should throw NotFoundException") {
+                // given
+                val requests =
+                    listOf(
+                        DeleteWordDefinitionApplication.Request(
+                            wordId = word!!.id!!,
+                            wordDefinitionId = 9999L,
+                        ),
+                        DeleteWordDefinitionApplication.Request(
+                            wordId = 9999L,
+                            wordDefinitionId = wordDefinitionId,
+                        ),
+                    )
+
+                // when & then
+                requests.forEach { request ->
+                    val exception = shouldThrow<NotFoundException> { subject.run(request) }
+
+                    exception.message shouldBe "Word definition not found"
+                    exception.code shouldBe "WORD_4"
+                }
+            }
+        }
+
+        describe("when wordDefinitionId of wordId exists") {
+            it("should throw BadRequestException if already deleted") {
+                // given
+                word!!.removeDefinition(wordDefinitionId)
+                wordRepository.save(word!!)
+
+                val request =
+                    DeleteWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        wordDefinitionId = wordDefinitionId,
+                    )
+
+                // when & then
+                val exception = shouldThrow<BadRequestException> { subject.run(request) }
+
+                exception.message shouldBe "Cannot delete word definition that is not pending or not used"
+                exception.code shouldBe "WORD_7"
+            }
+
+            it("should throw BadRequestException if already used") {
+                // given
+                wordRepository.save(word!!)
+                val user = userFactory.createUser()
+                studyFactory.createStudy(userId = user.id!!, wordDefinitionId = wordDefinitionId)
+
+                val request =
+                    DeleteWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        wordDefinitionId = wordDefinitionId,
+                    )
+
+                // when & then
+                val exception = shouldThrow<BadRequestException> { subject.run(request) }
+
+                exception.message shouldBe "Cannot delete word definition that is not pending or not used"
+                exception.code shouldBe "WORD_7"
+            }
+
+            it("should delete word definition") {
+                // scenario 1. deleting live word definition with no one studying it
+                // given
+                val request =
+                    DeleteWordDefinitionApplication.Request(
+                        wordId = word!!.id!!,
+                        wordDefinitionId = wordDefinitionId,
+                    )
+
+                // when
+                val response = subject.run(request)
+
+                // then
+                response.word.id shouldBe word!!.id
+                response.word.definitions.size shouldBe word!!.definitions.size
+                response.word.definitions
+                    .find { it.id == wordDefinitionId }!!
+                    .let { it.status shouldBe StatusType.REMOVED }
+
+                // scenario 2. deleting pending word definition
+                // given
+                word = wordRepository.findById(word!!.id!!).get()
+                word!!.addDefinitions(
+                    listOf(
+                        WordDefinition(
+                            wordId = word!!.id!!,
+                            lexicalCategory = LexicalCategoryType.VERB,
+                            meaning = "예약하다",
+                            preContext = "특정한 날짜나 시간에 무엇을 하기 위해 미리 자리를 확보하다",
+                        ),
+                    ),
+                )
+                val updatedWord = wordRepository.save(word!!)
+                wordDefinitionId = updatedWord.definitions.find { it.status == StatusType.PENDING }!!.id!!
+
+                val request2 =
+                    DeleteWordDefinitionApplication.Request(
+                        wordId = updatedWord.id!!,
+                        wordDefinitionId = wordDefinitionId,
+                    )
+
+                // when
+                val response2 = subject.run(request2)
+
+                // then
+                response2.word.id shouldBe updatedWord.id
+                response2.word.definitions.size shouldBe updatedWord.definitions.size
+                response2.word.definitions
+                    .find { it.id == wordDefinitionId }!!
+                    .let { it.status shouldBe StatusType.REMOVED }
+            }
+        }
+    })

--- a/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
+++ b/app/src/test/kotlin/com/inout/apiserver/domain/word/WordFactory.kt
@@ -8,6 +8,7 @@ import com.inout.apiserver.base.alias.WordDefinitionId
 import com.inout.apiserver.base.enums.LanguageType
 import com.inout.apiserver.base.enums.LexicalCategoryType
 import com.inout.apiserver.base.enums.SentenceType
+import com.inout.apiserver.base.enums.StatusType
 import com.inout.apiserver.infrastructure.db.word.Conversation
 import com.inout.apiserver.infrastructure.db.word.ConversationRepository
 import com.inout.apiserver.infrastructure.db.word.Sentence
@@ -53,7 +54,11 @@ class WordFactory(
                     toLanguage = toLanguage,
                 ),
             )
-        word.addDefinitions(wordDefinitions.map { WordDefinition.fromCreateObject(it, word) })
+        word.addDefinitions(
+            wordDefinitions.map {
+                WordDefinition.fromCreateObject(it, word).copy(status = StatusType.LIVE)
+            },
+        )
         return wordRepository.save(word).let { wordRepository.findById(it.id!!).get() }
     }
 


### PR DESCRIPTION
### New Enum

- add new enum to denote status of entity: StatusType

### DB
- applied StatusType to WordDefinition & add flyway migration
  - set to "PENDING" as default.
  - no need to update existing word definitions as this is service is not live yet

### Test
- make WordFactory's createWord automatically set status as LIVE
  - why? tests on words are based on usable words

### Controller
- add AdminWordController
  - responsible for handling words manually by admins
- move word create api to admin


### Business Logic
- add CreateWordManualApplication
  - creating word manually by admin
- add AddWordDefinitionApplication
  - added to handle AI not coming up with the right/insufficient definitions
- add ApproveWordDefinitionApplication
  - finalizing whether use can use the word definition by admin
  - add async sentence creation on definition approval
- add DeleteWordDefinitionApplication
  - handle unused / still pending word definition deletion
  - no support for used word definition deletion - this should be done with analysis / human consideration
- add word definition exist check on StudyRepository

### etc
- add status field on WordDefinitionResponse

https://inoutedu.atlassian.net/browse/IO-67

--- 

# Next Step

- [ ] Admin authorization
- [ ] Word & definitions query - users should be able to only see & study definitions with LIVE status